### PR TITLE
Refactor server 

### DIFF
--- a/crates/tuono/Cargo.toml
+++ b/crates/tuono/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuono"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["V. Ageno <valerioageno@yahoo.it>"]
 description = "The react/rust fullstack framework"

--- a/crates/tuono/src/source_builder.rs
+++ b/crates/tuono/src/source_builder.rs
@@ -68,8 +68,6 @@ async fn main() {
 
 const ROOT_FOLDER: &str = "src/routes";
 const DEV_FOLDER: &str = ".tuono";
-const DEV_PUBLIC_DIR: &str = "public";
-const PROD_PUBLIC_DIR: &str = "out/client";
 
 #[derive(Debug, PartialEq, Eq)]
 struct Route {
@@ -213,12 +211,6 @@ pub fn bundle_axum_source(mode: Mode) -> io::Result<()> {
 }
 
 fn generate_axum_source(source_builder: &SourceBuilder, mode: Mode) -> String {
-    let public_dir = if mode == Mode::Prod {
-        PROD_PUBLIC_DIR
-    } else {
-        DEV_PUBLIC_DIR
-    };
-
     AXUM_ENTRY_POINT
         .replace(
             "// ROUTE_BUILDER\n",
@@ -228,7 +220,6 @@ fn generate_axum_source(source_builder: &SourceBuilder, mode: Mode) -> String {
             "// MODULE_IMPORTS\n",
             &create_modules_declaration(&source_builder.route_map),
         )
-        .replace("/*public_dir*/", public_dir)
         .replace("/*MODE*/", mode.as_str())
 }
 
@@ -370,21 +361,5 @@ mod tests {
         let prod = Mode::Prod.as_str();
         assert_eq!(dev, "Mode::Dev");
         assert_eq!(prod, "Mode::Prod");
-    }
-
-    #[test]
-    fn should_replace_the_correct_public_folder_dev() {
-        let source_builder = SourceBuilder::new();
-        let source = generate_axum_source(&source_builder, Mode::Dev);
-
-        assert!(source.contains(r#"ServeDir::new("public")"#))
-    }
-
-    #[test]
-    fn should_replace_the_correct_public_folder_prod() {
-        let source_builder = SourceBuilder::new();
-        let source = generate_axum_source(&source_builder, Mode::Prod);
-
-        assert!(source.contains(r#"ServeDir::new("out/client")"#))
     }
 }

--- a/crates/tuono/src/source_builder.rs
+++ b/crates/tuono/src/source_builder.rs
@@ -47,7 +47,7 @@ pub const AXUM_ENTRY_POINT: &str = r##"
 // File automatically generated
 // Do not manually change it
 
-use tuono_lib::{Mode, server::Server, Router, get};
+use tuono_lib::{tokio, Mode, server::Server, axum::Router, axum::routing::get};
 use reqwest::Client;
 
 const MODE: Mode = /*MODE*/;

--- a/crates/tuono/src/source_builder.rs
+++ b/crates/tuono/src/source_builder.rs
@@ -47,7 +47,7 @@ pub const AXUM_ENTRY_POINT: &str = r##"
 // File automatically generated
 // Do not manually change it
 
-use tuono_lib::{tokio, Mode, server::Server, axum::Router, axum::routing::get};
+use tuono_lib::{tokio, Mode, Server, axum::Router, axum::routing::get};
 use reqwest::Client;
 
 const MODE: Mode = /*MODE*/;

--- a/crates/tuono/src/source_builder.rs
+++ b/crates/tuono/src/source_builder.rs
@@ -47,9 +47,7 @@ pub const AXUM_ENTRY_POINT: &str = r##"
 // File automatically generated
 // Do not manually change it
 
-use axum::{routing::get, Router};
-use tower_http::services::ServeDir;
-use tuono_lib::{Ssr, Mode, GLOBAL_MODE, manifest::load_manifest, server::Server};
+use tuono_lib::{Mode, server::Server, Router, get};
 use reqwest::Client;
 
 const MODE: Mode = /*MODE*/;
@@ -58,22 +56,13 @@ const MODE: Mode = /*MODE*/;
 
 #[tokio::main]
 async fn main() {
-    Ssr::create_platform();
-
     let fetch = Client::new();
-
-    GLOBAL_MODE.set(MODE).unwrap();
-
-    if MODE == Mode::Prod {
-        load_manifest()
-    }
 
     let router = Router::new()
         // ROUTE_BUILDER
-        .fallback_service(ServeDir::new("/*public_dir*/").fallback(get(tuono_lib::catch_all::catch_all)))
         .with_state(fetch);
 
-    Server::init(router).start().await
+    Server::init(router, MODE).start().await
 }
 "##;
 

--- a/crates/tuono/src/source_builder.rs
+++ b/crates/tuono/src/source_builder.rs
@@ -49,7 +49,7 @@ pub const AXUM_ENTRY_POINT: &str = r##"
 
 use axum::{routing::get, Router};
 use tower_http::services::ServeDir;
-use tuono_lib::{Ssr, Mode, GLOBAL_MODE, manifest::load_manifest};
+use tuono_lib::{Ssr, Mode, GLOBAL_MODE, manifest::load_manifest, server::Server};
 use reqwest::Client;
 
 const MODE: Mode = /*MODE*/;
@@ -68,19 +68,12 @@ async fn main() {
         load_manifest()
     }
 
-    let app = Router::new()
+    let router = Router::new()
         // ROUTE_BUILDER
         .fallback_service(ServeDir::new("/*public_dir*/").fallback(get(tuono_lib::catch_all::catch_all)))
         .with_state(fetch);
 
-    let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
-
-    if MODE == Mode::Dev {
-        println!("\nDevelopment app ready at http://localhost:3000/");
-    } else {
-        println!("\nProduction app ready at http://localhost:3000/");
-    }
-    axum::serve(listener, app).await.unwrap();
+    Server::init(router).start().await
 }
 "##;
 

--- a/crates/tuono/src/source_builder.rs
+++ b/crates/tuono/src/source_builder.rs
@@ -47,12 +47,9 @@ pub const AXUM_ENTRY_POINT: &str = r##"
 // File automatically generated
 // Do not manually change it
 
-use axum::extract::{Path, Request};
-use axum::response::Html;
 use axum::{routing::get, Router};
 use tower_http::services::ServeDir;
-use std::collections::HashMap;
-use tuono_lib::{ssr, Ssr, Mode, GLOBAL_MODE, manifest::load_manifest};
+use tuono_lib::{Ssr, Mode, GLOBAL_MODE, manifest::load_manifest};
 use reqwest::Client;
 
 const MODE: Mode = /*MODE*/;
@@ -73,7 +70,7 @@ async fn main() {
 
     let app = Router::new()
         // ROUTE_BUILDER
-        .fallback_service(ServeDir::new("/*public_dir*/").fallback(get(catch_all)))
+        .fallback_service(ServeDir::new("/*public_dir*/").fallback(get(tuono_lib::catch_all::catch_all)))
         .with_state(fetch);
 
     let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
@@ -84,26 +81,6 @@ async fn main() {
         println!("\nProduction app ready at http://localhost:3000/");
     }
     axum::serve(listener, app).await.unwrap();
-}
-
-async fn catch_all(Path(params): Path<HashMap<String, String>>, request: Request) -> Html<String> {
-    let pathname = &request.uri();
-    let headers = &request.headers();
-
-    let req = tuono_lib::Request::new(pathname, headers, params);
-
-
-    // TODO: remove unwrap
-    let payload = tuono_lib::Payload::new(&req, &"")
-        .client_payload()
-        .unwrap();
-
-    let result = ssr::Js::SSR.with(|ssr| ssr.borrow_mut().render_to_string(Some(&payload)));
-
-    match result {
-        Ok(html) => Html(html),
-        _ => Html("500 internal server error".to_string()),
-    }
 }
 "##;
 

--- a/crates/tuono_lib/Cargo.toml
+++ b/crates/tuono_lib/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/lib.rs"
 [dependencies]
 ssr_rs = "0.5.5"
 axum = {version = "0.7.5", features = ["json"]}
+tokio = { version = "1.37.0", features = ["full"] }
 serde = { version = "1.0.202", features = ["derive"] }
 erased-serde = "0.4.5"
 serde_json = "1.0"

--- a/crates/tuono_lib/Cargo.toml
+++ b/crates/tuono_lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuono_lib"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["V. Ageno <valerioageno@yahoo.it>"]
 description = "The react/rust fullstack framework"
@@ -25,7 +25,7 @@ serde = { version = "1.0.202", features = ["derive"] }
 erased-serde = "0.4.5"
 serde_json = "1.0"
 
-tuono_lib_macros = {path = "../tuono_lib_macros", version = "0.3.0"}
+tuono_lib_macros = {path = "../tuono_lib_macros", version = "0.3.1"}
 once_cell = "1.19.0"
 lazy_static = "1.5.0"
 regex = "1.10.5"

--- a/crates/tuono_lib/Cargo.toml
+++ b/crates/tuono_lib/Cargo.toml
@@ -30,4 +30,5 @@ once_cell = "1.19.0"
 lazy_static = "1.5.0"
 regex = "1.10.5"
 either = "1.13.0"
+tower-http = {version = "0.5.2", features = ["fs"]}
 

--- a/crates/tuono_lib/Cargo.toml
+++ b/crates/tuono_lib/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/lib.rs"
 
 [dependencies]
 ssr_rs = "0.5.5"
-axum = "0.7.5"
+axum = {version = "0.7.5", features = ["json"]}
 serde = { version = "1.0.202", features = ["derive"] }
 erased-serde = "0.4.5"
 serde_json = "1.0"

--- a/crates/tuono_lib/src/catch_all.rs
+++ b/crates/tuono_lib/src/catch_all.rs
@@ -1,0 +1,24 @@
+use crate::{ssr::Js, Payload};
+use axum::extract::{Path, Request};
+use axum::response::Html;
+use std::collections::HashMap;
+
+pub async fn catch_all(
+    Path(params): Path<HashMap<String, String>>,
+    request: Request,
+) -> Html<String> {
+    let pathname = &request.uri();
+    let headers = &request.headers();
+
+    let req = crate::Request::new(pathname, headers, params);
+
+    // TODO: remove unwrap
+    let payload = Payload::new(&req, &"").client_payload().unwrap();
+
+    let result = Js::SSR.with(|ssr| ssr.borrow_mut().render_to_string(Some(&payload)));
+
+    match result {
+        Ok(html) => Html(html),
+        _ => Html("500 internal server error".to_string()),
+    }
+}

--- a/crates/tuono_lib/src/lib.rs
+++ b/crates/tuono_lib/src/lib.rs
@@ -1,19 +1,19 @@
-pub mod manifest;
+mod catch_all;
+mod manifest;
 mod mode;
 mod payload;
 mod request;
 mod response;
+mod server;
+mod ssr;
 
-pub mod catch_all;
-pub mod server;
-pub mod ssr;
-
-pub use axum;
-pub use tokio;
-
-pub use mode::{Mode, GLOBAL_MODE};
+pub use mode::Mode;
 pub use payload::Payload;
 pub use request::Request;
 pub use response::{Props, Response};
-pub use ssr_rs::Ssr;
+pub use server::Server;
 pub use tuono_lib_macros::handler;
+
+// Re-exports
+pub use axum;
+pub use tokio;

--- a/crates/tuono_lib/src/lib.rs
+++ b/crates/tuono_lib/src/lib.rs
@@ -5,6 +5,7 @@ mod request;
 mod response;
 
 pub mod catch_all;
+pub mod server;
 pub mod ssr;
 
 pub use mode::{Mode, GLOBAL_MODE};

--- a/crates/tuono_lib/src/lib.rs
+++ b/crates/tuono_lib/src/lib.rs
@@ -8,8 +8,8 @@ pub mod catch_all;
 pub mod server;
 pub mod ssr;
 
-pub use axum::routing::get;
-pub use axum::Router;
+pub use axum;
+pub use tokio;
 
 pub use mode::{Mode, GLOBAL_MODE};
 pub use payload::Payload;

--- a/crates/tuono_lib/src/lib.rs
+++ b/crates/tuono_lib/src/lib.rs
@@ -4,6 +4,7 @@ mod payload;
 mod request;
 mod response;
 
+pub mod catch_all;
 pub mod ssr;
 
 pub use mode::{Mode, GLOBAL_MODE};

--- a/crates/tuono_lib/src/lib.rs
+++ b/crates/tuono_lib/src/lib.rs
@@ -8,6 +8,9 @@ pub mod catch_all;
 pub mod server;
 pub mod ssr;
 
+pub use axum::routing::get;
+pub use axum::Router;
+
 pub use mode::{Mode, GLOBAL_MODE};
 pub use payload::Payload;
 pub use request::Request;

--- a/crates/tuono_lib/src/payload.rs
+++ b/crates/tuono_lib/src/payload.rs
@@ -1,4 +1,5 @@
-use crate::{manifest::MANIFEST, Mode, GLOBAL_MODE};
+use crate::manifest::MANIFEST;
+use crate::mode::{Mode, GLOBAL_MODE};
 use erased_serde::Serialize;
 use regex::Regex;
 use serde::Serialize as SerdeSerialize;

--- a/crates/tuono_lib/src/server.rs
+++ b/crates/tuono_lib/src/server.rs
@@ -1,0 +1,25 @@
+use crate::mode::{Mode, GLOBAL_MODE};
+
+use axum::routing::Router;
+
+pub struct Server {
+    router: Router,
+}
+
+impl Server {
+    pub fn init(router: Router) -> Server {
+        Server { router }
+    }
+
+    pub async fn start(&self) {
+        let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
+
+        if *GLOBAL_MODE.get().unwrap() == Mode::Dev {
+            println!("\nDevelopment app ready at http://localhost:3000/");
+        } else {
+            println!("\nProduction app ready at http://localhost:3000/");
+        }
+
+        axum::serve(listener, self.router.to_owned()).await.unwrap();
+    }
+}

--- a/crates/tuono_lib/src/server.rs
+++ b/crates/tuono_lib/src/server.rs
@@ -5,6 +5,8 @@ use axum::routing::{get, Router};
 use ssr_rs::Ssr;
 use tower_http::services::ServeDir;
 
+use crate::catch_all::catch_all;
+
 const DEV_PUBLIC_DIR: &str = "public";
 const PROD_PUBLIC_DIR: &str = "out/client";
 
@@ -44,7 +46,7 @@ impl Server {
         let router = self
             .router
             .to_owned()
-            .fallback_service(ServeDir::new(public_dir).fallback(get(crate::catch_all::catch_all)));
+            .fallback_service(ServeDir::new(public_dir).fallback(get(catch_all)));
 
         axum::serve(listener, router).await.unwrap();
     }

--- a/crates/tuono_lib/src/server.rs
+++ b/crates/tuono_lib/src/server.rs
@@ -1,25 +1,51 @@
 use crate::mode::{Mode, GLOBAL_MODE};
 
-use axum::routing::Router;
+use crate::manifest::load_manifest;
+use axum::routing::{get, Router};
+use ssr_rs::Ssr;
+use tower_http::services::ServeDir;
+
+const DEV_PUBLIC_DIR: &str = "public";
+const PROD_PUBLIC_DIR: &str = "out/client";
 
 pub struct Server {
     router: Router,
+    mode: Mode,
 }
 
 impl Server {
-    pub fn init(router: Router) -> Server {
-        Server { router }
+    pub fn init(router: Router, mode: Mode) -> Server {
+        Ssr::create_platform();
+
+        GLOBAL_MODE.set(mode).unwrap();
+
+        if mode == Mode::Prod {
+            load_manifest()
+        }
+
+        Server { router, mode }
     }
 
     pub async fn start(&self) {
         let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
 
-        if *GLOBAL_MODE.get().unwrap() == Mode::Dev {
+        if self.mode == Mode::Dev {
             println!("\nDevelopment app ready at http://localhost:3000/");
         } else {
             println!("\nProduction app ready at http://localhost:3000/");
         }
 
-        axum::serve(listener, self.router.to_owned()).await.unwrap();
+        let public_dir = if self.mode == Mode::Dev {
+            DEV_PUBLIC_DIR
+        } else {
+            PROD_PUBLIC_DIR
+        };
+
+        let router = self
+            .router
+            .to_owned()
+            .fallback_service(ServeDir::new(public_dir).fallback(get(crate::catch_all::catch_all)));
+
+        axum::serve(listener, router).await.unwrap();
     }
 }

--- a/crates/tuono_lib/src/ssr.rs
+++ b/crates/tuono_lib/src/ssr.rs
@@ -1,4 +1,4 @@
-use crate::{Mode, GLOBAL_MODE};
+use crate::mode::{Mode, GLOBAL_MODE};
 use lazy_static::lazy_static;
 use ssr_rs::Ssr;
 use std::cell::RefCell;

--- a/crates/tuono_lib_macros/Cargo.toml
+++ b/crates/tuono_lib_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuono_lib_macros"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "The react/rust fullstack framework"
 repository = "https://github.com/Valerioageno/tuono"

--- a/crates/tuono_lib_macros/src/handler.rs
+++ b/crates/tuono_lib_macros/src/handler.rs
@@ -8,9 +8,9 @@ pub fn handler_core(_args: TokenStream, item: TokenStream) -> TokenStream {
     let fn_name = item.clone().sig.ident;
 
     quote! {
-        use axum::response::IntoResponse;
+        use tuono_lib::axum::response::IntoResponse;
         use std::collections::HashMap;
-        use axum::extract::{State, Path};
+        use tuono_lib::axum::extract::{State, Path};
         use reqwest::Client;
 
         #item
@@ -18,7 +18,7 @@ pub fn handler_core(_args: TokenStream, item: TokenStream) -> TokenStream {
         pub async fn route(
             Path(params): Path<HashMap<String, String>>,
             State(client): State<Client>,
-            request: axum::extract::Request
+            request: tuono_lib::axum::extract::Request
         ) -> impl IntoResponse {
            let pathname = &request.uri();
            let headers = &request.headers();
@@ -31,7 +31,7 @@ pub fn handler_core(_args: TokenStream, item: TokenStream) -> TokenStream {
         pub async fn api(
             Path(params): Path<HashMap<String, String>>,
             State(client): State<Client>,
-            request: axum::extract::Request
+            request: tuono_lib::axum::extract::Request
         ) -> impl IntoResponse{
            let pathname = &request.uri();
            let headers = &request.headers();

--- a/examples/tuono/Cargo.toml
+++ b/examples/tuono/Cargo.toml
@@ -8,11 +8,5 @@ name = "tuono"
 path = ".tuono/main.rs"
 
 [dependencies]
-axum = {version = "0.7.5", features = ["json"]}
-tokio = { version = "1.37.0", features = ["full"] }
-tower-http = {version = "0.5.2", features = ["fs"]}
-serde = { version = "1.0.202", features = ["derive"] }
 tuono_lib = { path = "../../crates/tuono_lib/"}
-serde_json = "1.0"
-reqwest = {version = "0.12.4", features = ["json"]}
 

--- a/examples/tutorial/Cargo.toml
+++ b/examples/tutorial/Cargo.toml
@@ -8,11 +8,7 @@ name = "tuono"
 path = ".tuono/main.rs"
 
 [dependencies]
-axum = {version = "0.7.5", features = ["json"]}
-tokio = { version = "1.37.0", features = ["full"] }
-tower-http = {version = "0.5.2", features = ["fs"]}
-serde = { version = "1.0.202", features = ["derive"] }
 tuono_lib = { path = "../../crates/tuono_lib/"}
-serde_json = "1.0"
+serde = { version = "1.0.202", features = ["derive"] }
 reqwest = {version = "0.12.4", features = ["json"]}
 

--- a/packages/lazy-fn-vite-plugin/package.json
+++ b/packages/lazy-fn-vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tuono-lazy-fn-vite-plugin",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Plugin for the tuono's lazy fn. Tuono is the react/rust fullstack framework",
   "scripts": {
     "dev": "vite build --watch",

--- a/packages/tuono/package.json
+++ b/packages/tuono/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tuono",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "The react/rust fullstack framework",
   "scripts": {
     "dev": "vite build --watch",


### PR DESCRIPTION
## Why
The server was getting too complex to be handled by code generator side. 
Generating the server code using strings is complex and error prone for multilpe reasons.
Handling the server code directly within the `tuono_lib` create will help the project by:
- Easing the development
- Allowing the final projects to import just tuono_lib for what concerns the server management
- Allowing the final project to keep all the server related libs on sync