### PR TITLE
Remove lifetime notation on Request

### DIFF
--- a/crates/tuono/Cargo.toml
+++ b/crates/tuono/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuono"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2021"
 authors = ["V. Ageno <valerioageno@yahoo.it>"]
 description = "The react/rust fullstack framework"

--- a/crates/tuono_lib/Cargo.toml
+++ b/crates/tuono_lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuono_lib"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2021"
 authors = ["V. Ageno <valerioageno@yahoo.it>"]
 description = "The react/rust fullstack framework"
@@ -31,7 +31,7 @@ regex = "1.10.5"
 either = "1.13.0"
 tower-http = {version = "0.5.2", features = ["fs"]}
 
-tuono_lib_macros = {path = "../tuono_lib_macros", version = "0.4.4"}
+tuono_lib_macros = {path = "../tuono_lib_macros", version = "0.4.5"}
 # Match the same version used by axum
 tokio-tungstenite = "0.21.0"
 futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }

--- a/crates/tuono_lib/src/catch_all.rs
+++ b/crates/tuono_lib/src/catch_all.rs
@@ -7,10 +7,10 @@ pub async fn catch_all(
     Path(params): Path<HashMap<String, String>>,
     request: Request,
 ) -> Html<String> {
-    let pathname = &request.uri();
-    let headers = &request.headers();
+    let pathname = request.uri();
+    let headers = request.headers();
 
-    let req = crate::Request::new(pathname, headers, params);
+    let req = crate::Request::new(pathname.to_owned(), headers.to_owned(), params);
 
     // TODO: remove unwrap
     let payload = Payload::new(&req, &"").client_payload().unwrap();

--- a/crates/tuono_lib/src/payload.rs
+++ b/crates/tuono_lib/src/payload.rs
@@ -24,7 +24,7 @@ pub struct Payload<'a> {
 }
 
 impl<'a> Payload<'a> {
-    pub fn new(req: &Request<'a>, props: &'a dyn Serialize) -> Payload<'a> {
+    pub fn new(req: &Request, props: &'a dyn Serialize) -> Payload<'a> {
         Payload {
             router: req.location(),
             props,
@@ -186,7 +186,7 @@ mod tests {
         );
         MANIFEST.get_or_init(|| manifest_mock);
         let location = Location::from(
-            &uri.unwrap_or("http://localhost:3000/")
+            uri.unwrap_or("http://localhost:3000/")
                 .parse::<Uri>()
                 .unwrap(),
         );

--- a/crates/tuono_lib/src/request.rs
+++ b/crates/tuono_lib/src/request.rs
@@ -19,8 +19,8 @@ impl Location {
     }
 }
 
-impl<'a> From<&'a Uri> for Location {
-    fn from(uri: &Uri) -> Self {
+impl From<Uri> for Location {
+    fn from(uri: Uri) -> Self {
         Location {
             href: uri.to_string(),
             pathname: uri.path().to_string(),
@@ -33,18 +33,14 @@ impl<'a> From<&'a Uri> for Location {
 }
 
 #[derive(Debug, Clone)]
-pub struct Request<'a> {
-    uri: &'a Uri,
-    pub headers: &'a HeaderMap,
+pub struct Request {
+    uri: Uri,
+    pub headers: HeaderMap,
     pub params: HashMap<String, String>,
 }
 
-impl<'a> Request<'a> {
-    pub fn new(
-        uri: &'a Uri,
-        headers: &'a HeaderMap,
-        params: HashMap<String, String>,
-    ) -> Request<'a> {
+impl Request {
+    pub fn new(uri: Uri, headers: HeaderMap, params: HashMap<String, String>) -> Request {
         Request {
             uri,
             headers,
@@ -53,6 +49,6 @@ impl<'a> Request<'a> {
     }
 
     pub fn location(&self) -> Location {
-        Location::from(self.uri)
+        Location::from(self.uri.to_owned())
     }
 }

--- a/crates/tuono_lib_macros/Cargo.toml
+++ b/crates/tuono_lib_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuono_lib_macros"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2021"
 description = "The react/rust fullstack framework"
 keywords = [ "react", "typescript", "fullstack", "web", "ssr"]

--- a/crates/tuono_lib_macros/src/handler.rs
+++ b/crates/tuono_lib_macros/src/handler.rs
@@ -19,10 +19,10 @@ pub fn handler_core(_args: TokenStream, item: TokenStream) -> TokenStream {
             State(client): State<tuono_lib::reqwest::Client>,
             request: tuono_lib::axum::extract::Request
         ) -> impl IntoResponse {
-           let pathname = &request.uri();
-           let headers = &request.headers();
+           let pathname = request.uri();
+           let headers = request.headers();
 
-           let req = tuono_lib::Request::new(pathname, headers, params);
+           let req = tuono_lib::Request::new(pathname.to_owned(), headers.to_owned(), params);
 
            #fn_name(req.clone(), client).await.render_to_string(req)
         }
@@ -32,10 +32,10 @@ pub fn handler_core(_args: TokenStream, item: TokenStream) -> TokenStream {
             State(client): State<tuono_lib::reqwest::Client>,
             request: tuono_lib::axum::extract::Request
         ) -> impl IntoResponse{
-           let pathname = &request.uri();
-           let headers = &request.headers();
+           let pathname = request.uri();
+           let headers = request.headers();
 
-           let req = tuono_lib::Request::new(pathname, headers, params);
+           let req = tuono_lib::Request::new(pathname.to_owned(), headers.to_owned(), params);
 
            #fn_name(req.clone(), client).await.json()
         }

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -136,7 +136,7 @@ struct Pokemon {
 }
 
 #[tuono_lib::handler]
-async fn get_all_pokemons(_req: Request<'_>, fetch: Client) -> Response {
+async fn get_all_pokemons(_req: Request, fetch: Client) -> Response {
     return match fetch.get(ALL_POKEMON).send().await {
         Ok(res) => {
             let data = res.json::<Pokemons>().await.unwrap();
@@ -343,7 +343,7 @@ struct Pokemon {
 }
 
 #[tuono_lib::handler]
-async fn get_pokemon(req: Request<'_>, fetch: Client) -> Response {
+async fn get_pokemon(req: Request, fetch: Client) -> Response {
     // The param `pokemon` is defined in the route filename [pokemon].rs
     let pokemon = req.params.get("pokemon").unwrap();
 
@@ -486,7 +486,7 @@ struct Pokemon {
 }
 
 #[tuono_lib::handler]
-async fn get_pokemon(req: Request<'_>, fetch: Client) -> Response {
+async fn get_pokemon(req: Request, fetch: Client) -> Response {
     // The param `pokemon` is defined in the route filename [pokemon].rs
     let pokemon = req.params.get("pokemon").unwrap();
 
@@ -529,7 +529,7 @@ struct Pokemon {
 }
 
 #[tuono_lib::handler]
-async fn get_all_pokemons(_req: Request<'_>, fetch: Client) -> Response {
+async fn get_all_pokemons(_req: Request, fetch: Client) -> Response {
     return match fetch.get(ALL_POKEMON).send().await {
         Ok(res) => {
             let data = res.json::<Pokemons>().await.unwrap();
@@ -560,7 +560,7 @@ First let's create a new route by just creating an new file `/pokemons/GOAT.rs` 
 use tuono_lib::{reqwest::Client, Request, Response};
 
 #[tuono_lib::handler]
-async fn redirect_to_goat(_: Request<'_>, _: Client) -> Response {
+async fn redirect_to_goat(_: Request, _: Client) -> Response {
     // Of course the GOAT is mewtwo - feel free to select your favourite 😉
     Response::Redirect("/pokemons/mewtwo".to_string()) 
 }

--- a/examples/tuono/Cargo.toml
+++ b/examples/tuono/Cargo.toml
@@ -9,4 +9,5 @@ path = ".tuono/main.rs"
 
 [dependencies]
 tuono_lib = { path = "../../crates/tuono_lib/"}
+serde = { version = "1.0.202", features = ["derive"] }
 

--- a/examples/tuono/src/routes/index.rs
+++ b/examples/tuono/src/routes/index.rs
@@ -1,4 +1,5 @@
 use serde::Serialize;
+use tuono_lib::reqwest;
 use tuono_lib::{Props, Request, Response};
 
 #[derive(Serialize)]
@@ -7,7 +8,7 @@ struct MyResponse<'a> {
 }
 
 #[tuono_lib::handler]
-async fn get_server_side_props(_req: Request<'_>, _fetch: reqwest::Client) -> Response {
+async fn get_server_side_props(_req: Request, _fetch: reqwest::Client) -> Response {
     Response::Props(Props::new(MyResponse {
         subtitle: "The react / rust fullstack framework",
     }))

--- a/examples/tutorial/src/routes/index.rs
+++ b/examples/tutorial/src/routes/index.rs
@@ -17,7 +17,7 @@ struct Pokemon {
 }
 
 #[tuono_lib::handler]
-async fn get_all_pokemons(_req: Request<'_>, fetch: Client) -> Response {
+async fn get_all_pokemons(_req: Request, fetch: Client) -> Response {
     match fetch.get(ALL_POKEMON).send().await {
         Ok(res) => {
             let data = res.json::<Pokemons>().await.unwrap();

--- a/examples/tutorial/src/routes/pokemons/GOAT.rs
+++ b/examples/tutorial/src/routes/pokemons/GOAT.rs
@@ -2,6 +2,6 @@
 use tuono_lib::{reqwest::Client, Request, Response};
 
 #[tuono_lib::handler]
-async fn redirect_to_goat(_: Request<'_>, _: Client) -> Response {
+async fn redirect_to_goat(_: Request, _: Client) -> Response {
     Response::Redirect("/pokemons/mewtwo".to_string())
 }

--- a/examples/tutorial/src/routes/pokemons/[pokemon].rs
+++ b/examples/tutorial/src/routes/pokemons/[pokemon].rs
@@ -14,7 +14,7 @@ struct Pokemon {
 }
 
 #[tuono_lib::handler]
-async fn get_pokemon(req: Request<'_>, fetch: Client) -> Response {
+async fn get_pokemon(req: Request, fetch: Client) -> Response {
     // The param `pokemon` is defined in the route filename [pokemon].rs
     let pokemon = req.params.get("pokemon").unwrap();
 

--- a/packages/fs-router-vite-plugin/package.json
+++ b/packages/fs-router-vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tuono-fs-router-vite-plugin",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Plugin for the tuono's file system router. Tuono is the react/rust fullstack framework",
   "scripts": {
     "dev": "vite build --watch",

--- a/packages/lazy-fn-vite-plugin/package.json
+++ b/packages/lazy-fn-vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tuono-lazy-fn-vite-plugin",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Plugin for the tuono's lazy fn. Tuono is the react/rust fullstack framework",
   "scripts": {
     "dev": "vite build --watch",

--- a/packages/tuono/package.json
+++ b/packages/tuono/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tuono",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "The react/rust fullstack framework",
   "scripts": {
     "dev": "vite build --watch",


### PR DESCRIPTION
## Description

This PR is a little improvement on the public API. 

```diff
-- pub async fn custom_handler(req: Request<'_>) ...
++ pub async fn custom_handler(req: Request) ...
```

