### PR TITLE
Support Static Site Generation (SSG)

### DIFF
--- a/crates/tuono/Cargo.toml
+++ b/crates/tuono/Cargo.toml
@@ -30,4 +30,5 @@ glob = "0.3.1"
 regex = "1.10.4"
 reqwest = {version = "0.12.4", features =["blocking", "json"]}
 serde_json = "1.0"
+fs_extra = "1.3.0"
 

--- a/crates/tuono/Cargo.toml
+++ b/crates/tuono/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuono"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 authors = ["V. Ageno <valerioageno@yahoo.it>"]
 description = "The react/rust fullstack framework"

--- a/crates/tuono/src/app.rs
+++ b/crates/tuono/src/app.rs
@@ -18,13 +18,17 @@ impl App {
     pub fn new() -> Self {
         let base_path = std::env::current_dir().unwrap();
 
-        App {
+        let mut app = App {
             route_map: HashMap::new(),
             base_path,
-        }
+        };
+
+        app.collect_routes();
+
+        app
     }
 
-    pub fn collect_routes(&mut self) {
+    fn collect_routes(&mut self) {
         glob(self.base_path.join("src/routes/**/*.*").to_str().unwrap())
             .expect("Failed to read glob pattern")
             .for_each(|entry| {

--- a/crates/tuono/src/cli.rs
+++ b/crates/tuono/src/cli.rs
@@ -58,8 +58,7 @@ pub fn app() -> std::io::Result<()> {
 
             if ssg {
                 println!("SSG: generation started");
-                let mut app = App::new();
-                app.collect_routes();
+                let app = App::new();
                 dbg!(app);
             }
         }

--- a/crates/tuono/src/cli.rs
+++ b/crates/tuono/src/cli.rs
@@ -53,6 +53,13 @@ pub fn app() -> std::io::Result<()> {
         Actions::Build { ssg } => {
             init_tuono_folder(Mode::Prod)?;
             let app = App::new();
+
+            if ssg && app.has_dynamic_routes() {
+                // TODO: allow dynamic routes static generation
+                println!("Cannot statically build dynamic routes");
+                return Ok(());
+            }
+
             app.build_react_prod();
 
             if ssg {

--- a/crates/tuono/src/cli.rs
+++ b/crates/tuono/src/cli.rs
@@ -1,3 +1,8 @@
+use fs_extra::dir::{copy, CopyOptions};
+use std::path::PathBuf;
+use std::thread::sleep;
+use std::time::Duration;
+
 use clap::{Parser, Subcommand};
 
 use crate::app::App;
@@ -64,8 +69,47 @@ pub fn app() -> std::io::Result<()> {
 
             if ssg {
                 println!("SSG: generation started");
+
+                let static_dir = PathBuf::from("out/static");
+
+                if static_dir.is_dir() {
+                    std::fs::remove_dir_all(&static_dir)
+                        .expect("Failed to clear the out/static folder");
+                }
+
+                std::fs::create_dir(&static_dir).expect("Failed to create static output dir");
+
+                copy(
+                    "./out/client",
+                    static_dir,
+                    &CopyOptions::new().overwrite(true).content_only(true),
+                )
+                .expect("Failed to clone assets into static output folder");
+
                 let mut rust_server = app.run_rust_server();
-                let _ = rust_server.wait();
+
+                let reqwest = reqwest::blocking::Client::builder()
+                    .user_agent("")
+                    .build()
+                    .expect("Failed to build reqwest client");
+
+                // Wait for server
+                let mut is_server_ready = false;
+
+                while !is_server_ready {
+                    if reqwest.get("http://localhost:3000").send().is_ok() {
+                        is_server_ready = true
+                    }
+                    // TODO: add maximum tries
+                    sleep(Duration::from_secs(1))
+                }
+
+                app.route_map
+                    .iter()
+                    .for_each(|(_, route)| route.save_ssg_html(&reqwest));
+
+                // Close server
+                let _ = rust_server.kill();
             };
 
             println!("Build successfully finished");

--- a/crates/tuono/src/cli.rs
+++ b/crates/tuono/src/cli.rs
@@ -1,5 +1,4 @@
 use clap::{Parser, Subcommand};
-use std::process::Command;
 
 use crate::app::App;
 use crate::mode::Mode;
@@ -53,14 +52,16 @@ pub fn app() -> std::io::Result<()> {
         }
         Actions::Build { ssg } => {
             init_tuono_folder(Mode::Prod)?;
-            let mut vite_build = Command::new("./node_modules/.bin/tuono-build-prod");
-            let _ = &vite_build.output()?;
+            let app = App::new();
+            app.build_react_prod();
 
             if ssg {
                 println!("SSG: generation started");
-                let app = App::new();
-                dbg!(app);
-            }
+                let mut rust_server = app.run_rust_server();
+                let _ = rust_server.wait();
+            };
+
+            println!("Build successfully finished");
         }
         Actions::New {
             folder_name,

--- a/crates/tuono/src/route.rs
+++ b/crates/tuono/src/route.rs
@@ -111,13 +111,9 @@ impl Route {
 
             let pathname = &format!("/__tuono/data{path}/data.json");
 
-            dbg!(pathname);
-
             let url = base
                 .join(pathname)
                 .expect("Failed to build the reqwest URL");
-
-            dbg!(&url);
 
             let mut response = reqwest.get(url).send().unwrap();
 

--- a/crates/tuono/src/source_builder.rs
+++ b/crates/tuono/src/source_builder.rs
@@ -106,12 +106,9 @@ fn create_modules_declaration(routes: &HashMap<String, Route>) -> String {
 pub fn bundle_axum_source(mode: Mode) -> io::Result<()> {
     let base_path = std::env::current_dir().unwrap();
 
-    let mut source_builder = App::new();
+    let app = App::new();
 
-    source_builder.collect_routes();
-
-    dbg!(&source_builder);
-    let bundled_file = generate_axum_source(&source_builder, mode);
+    let bundled_file = generate_axum_source(&app, mode);
 
     create_main_file(&base_path, &bundled_file);
 

--- a/crates/tuono/src/source_builder.rs
+++ b/crates/tuono/src/source_builder.rs
@@ -76,8 +76,9 @@ fn create_routes_declaration(routes: &HashMap<String, Route>) -> String {
             route_declarations.push_str(&format!(
                 r#".route("{axum_route}", get({module_import}::route))"#
             ));
+            let slash = if axum_route.ends_with('/') { "" } else { "/" };
             route_declarations.push_str(&format!(
-                r#".route("/__tuono/data{axum_route}", get({module_import}::api))"#
+                r#".route("/__tuono/data{axum_route}{slash}data.json", get({module_import}::api))"#
             ));
         }
     }

--- a/crates/tuono_lib/Cargo.toml
+++ b/crates/tuono_lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuono_lib"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 authors = ["V. Ageno <valerioageno@yahoo.it>"]
 description = "The react/rust fullstack framework"
@@ -32,7 +32,7 @@ regex = "1.10.5"
 either = "1.13.0"
 tower-http = {version = "0.5.2", features = ["fs"]}
 
-tuono_lib_macros = {path = "../tuono_lib_macros", version = "0.5.0"}
+tuono_lib_macros = {path = "../tuono_lib_macros", version = "0.6.0"}
 # Match the same version used by axum
 tokio-tungstenite = "0.21.0"
 futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }

--- a/crates/tuono_lib_macros/Cargo.toml
+++ b/crates/tuono_lib_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuono_lib_macros"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "The react/rust fullstack framework"
 keywords = [ "react", "typescript", "fullstack", "web", "ssr"]

--- a/packages/fs-router-vite-plugin/package.json
+++ b/packages/fs-router-vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tuono-fs-router-vite-plugin",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Plugin for the tuono's file system router. Tuono is the react/rust fullstack framework",
   "scripts": {
     "dev": "vite build --watch",

--- a/packages/lazy-fn-vite-plugin/package.json
+++ b/packages/lazy-fn-vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tuono-lazy-fn-vite-plugin",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Plugin for the tuono's lazy fn. Tuono is the react/rust fullstack framework",
   "scripts": {
     "dev": "vite build --watch",

--- a/packages/tuono/package.json
+++ b/packages/tuono/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tuono",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "The react/rust fullstack framework",
   "scripts": {
     "dev": "vite build --watch",

--- a/packages/tuono/src/router/hooks/useServerSideProps.tsx
+++ b/packages/tuono/src/router/hooks/useServerSideProps.tsx
@@ -24,7 +24,8 @@ interface TuonoApi {
 }
 
 const fetchClientSideData = async (): Promise<TuonoApi> => {
-  const res = await fetch(`/__tuono/data${location.pathname}`)
+  const slash = location.pathname.endsWith('/') ? '' : '/'
+  const res = await fetch(`/__tuono/data${location.pathname}${slash}data.json`)
   const data: TuonoApi = await res.json()
   return data
 }


### PR DESCRIPTION
## Context

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

This PR implements the SGG build option (`tuono build --static`). This in order to allow the development of websites that don't require any dynamic server capability.

This is the first iteration. The feature will be refined while working on the tuono documentation website trying to address real world deployment issues.

## Description

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/Valerioageno/tuono/blob/main/CONTRIBUTING.md
-->

The step taken by the tuono source builder to statically generate the website are:
1. Build the source with vite
2. Clone the output assets into the `out/static` folder
3. Run the prod server on port 3000
4. Call any existing route and save it in a [file].html file (if require server data it also saves `__tuono/data/[file]/data.json` file)