### PR TITLE
Add custom response type

### DIFF
--- a/crates/tuono/src/app.rs
+++ b/crates/tuono/src/app.rs
@@ -120,6 +120,7 @@ mod tests {
             "/home/user/Documents/tuono/src/routes/posts/index.rs",
             "/home/user/Documents/tuono/src/routes/posts/[post].rs",
             "/home/user/Documents/tuono/src/routes/posts/UPPERCASE.rs",
+            "/home/user/Documents/tuono/src/routes/sitemap.xml.rs",
         ];
 
         routes
@@ -132,6 +133,7 @@ mod tests {
             ("/posts/index", "posts_index"),
             ("/posts/[post]", "posts_dyn_post"),
             ("/posts/UPPERCASE", "posts_uppercase"),
+            ("/sitemap.xml", "sitemap_dot_xml"),
         ];
 
         results.into_iter().for_each(|(path, module_import)| {

--- a/crates/tuono/src/cli.rs
+++ b/crates/tuono/src/cli.rs
@@ -105,7 +105,7 @@ pub fn app() -> std::io::Result<()> {
                 }
 
                 for (_, route) in app.route_map {
-                    route.save_ssg_html(&reqwest)
+                    route.save_ssg_file(&reqwest)
                 }
 
                 // Close server

--- a/crates/tuono/src/route.rs
+++ b/crates/tuono/src/route.rs
@@ -27,9 +27,16 @@ impl AxumInfo {
 
         let axum_route = path.replace("/index", "");
 
+        let module_import = module
+            .as_str()
+            .to_string()
+            .replace('/', "_")
+            .replace('.', "_dot_")
+            .to_lowercase();
+
         if axum_route.is_empty() {
             return AxumInfo {
-                module_import: module.as_str().to_string().replace('/', "_"),
+                module_import,
                 axum_route: "/".to_string(),
             };
         }
@@ -47,7 +54,7 @@ impl AxumInfo {
         }
 
         AxumInfo {
-            module_import: module.as_str().to_string().replace('/', "_").to_lowercase(),
+            module_import,
             axum_route,
         }
     }


### PR DESCRIPTION
## Context & Description

<!--
Thank you for your Pull Request. 

Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/Valerioageno/tuono/blob/main/CONTRIBUTING.md
-->

To better support custom file generation (like `sitemap.xml`) the `Response` enum has now the new `Response::Custom` variant to return the defined file.

The build script has been updated as well to support the static generation (SGG) of such files.
