### PR TITLE
refactor: use `React.JSX` rather than global `JSX`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -49,7 +49,7 @@
     "@typescript-eslint/naming-convention": [
       "error",
       {
-		"selector": "typeParameter",
+        "selector": "typeParameter",
         "format": ["PascalCase"],
         "leadingUnderscore": "forbid",
         "trailingUnderscore": "forbid",
@@ -59,6 +59,7 @@
         },
       },
     ],
+    "@typescript-eslint/no-deprecated": "error",
     "@typescript-eslint/no-empty-function": "error",
     "@typescript-eslint/no-empty-interface": "error",
     "@typescript-eslint/no-explicit-any": "off",

--- a/apps/documentation/.eslintrc
+++ b/apps/documentation/.eslintrc
@@ -49,7 +49,7 @@
     "@typescript-eslint/naming-convention": [
       "error",
       {
-		"selector": "typeParameter",
+        "selector": "typeParameter",
         "format": ["PascalCase"],
         "leadingUnderscore": "forbid",
         "trailingUnderscore": "forbid",
@@ -59,6 +59,7 @@
         },
       },
     ],
+    "@typescript-eslint/no-deprecated": "error",
     "@typescript-eslint/no-empty-function": "error",
     "@typescript-eslint/no-empty-interface": "error",
     "@typescript-eslint/no-explicit-any": "off",

--- a/apps/documentation/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/apps/documentation/src/components/breadcrumbs/breadcrumbs.tsx
@@ -1,3 +1,4 @@
+import type { JSX } from 'react'
 import { Breadcrumbs, Button } from '@mantine/core'
 import { Link, Head } from 'tuono'
 

--- a/apps/documentation/src/components/edit-page/edit-page.tsx
+++ b/apps/documentation/src/components/edit-page/edit-page.tsx
@@ -1,3 +1,4 @@
+import type { JSX } from 'react'
 import { Button } from '@mantine/core'
 import { IconEdit } from '@tabler/icons-react'
 import { useRouter } from 'tuono'

--- a/apps/documentation/src/components/hero/hero.tsx
+++ b/apps/documentation/src/components/hero/hero.tsx
@@ -1,3 +1,4 @@
+import type { JSX } from 'react'
 import {
   Button,
   Center,

--- a/apps/documentation/src/components/mdx-provider/mdx-bold/mdx-bold.tsx
+++ b/apps/documentation/src/components/mdx-provider/mdx-bold/mdx-bold.tsx
@@ -1,3 +1,4 @@
+import type { JSX } from 'react'
 import { Text, type TextProps } from '@mantine/core'
 
 export default function MdxBold(props: TextProps): JSX.Element {

--- a/apps/documentation/src/components/mdx-provider/mdx-code/mdx-code.tsx
+++ b/apps/documentation/src/components/mdx-provider/mdx-code/mdx-code.tsx
@@ -1,3 +1,4 @@
+import type { JSX } from 'react'
 import { Code } from '@mantine/core'
 import type { HTMLAttributes } from 'react'
 

--- a/apps/documentation/src/components/mdx-provider/mdx-link/mdx-link.tsx
+++ b/apps/documentation/src/components/mdx-provider/mdx-link/mdx-link.tsx
@@ -1,4 +1,4 @@
-import type { AnchorHTMLAttributes } from 'react'
+import type { JSX, AnchorHTMLAttributes } from 'react'
 import { Button } from '@mantine/core'
 import { Link } from 'tuono'
 import { IconExternalLink } from '@tabler/icons-react'

--- a/apps/documentation/src/components/mdx-provider/mdx-pre/mdx-pre.tsx
+++ b/apps/documentation/src/components/mdx-provider/mdx-pre/mdx-pre.tsx
@@ -1,3 +1,4 @@
+import type { JSX } from 'react'
 import { CodeHighlight } from '@mantine/code-highlight'
 import styles from './mdx-pre.module.css'
 

--- a/apps/documentation/src/components/mdx-provider/mdx-provider.tsx
+++ b/apps/documentation/src/components/mdx-provider/mdx-provider.tsx
@@ -1,3 +1,4 @@
+import type { JSX } from 'react'
 import { MDXProvider } from '@mdx-js/react'
 
 import MdxLink from './mdx-link'

--- a/apps/documentation/src/components/mdx-provider/mdx-quote/mdx-quote.tsx
+++ b/apps/documentation/src/components/mdx-provider/mdx-quote/mdx-quote.tsx
@@ -1,5 +1,5 @@
+import type { JSX, HTMLAttributes } from 'react'
 import { Blockquote, Space } from '@mantine/core'
-import type { HTMLAttributes } from 'react'
 
 export default function MdxQuote(
   props: HTMLAttributes<HTMLQuoteElement>,

--- a/apps/documentation/src/components/mdx-provider/mdx-title/mdx-title.tsx
+++ b/apps/documentation/src/components/mdx-provider/mdx-title/mdx-title.tsx
@@ -1,3 +1,4 @@
+import type { JSX } from 'react'
 import { Title, type TitleProps } from '@mantine/core'
 
 export default function MdxTitle(props: TitleProps): JSX.Element {

--- a/apps/documentation/src/components/navbar/actions.tsx
+++ b/apps/documentation/src/components/navbar/actions.tsx
@@ -1,7 +1,9 @@
+import type { JSX } from 'react'
 import { Flex, Button, ActionIcon, Group } from '@mantine/core'
 import { IconBrandGithub, IconBook, IconBrandX } from '@tabler/icons-react'
-import ThemeBtn from '../theme-btn'
 import { Link } from 'tuono'
+
+import ThemeBtn from '../theme-btn'
 
 export default function Actions(): JSX.Element {
   return (

--- a/apps/documentation/src/components/navbar/navbar.tsx
+++ b/apps/documentation/src/components/navbar/navbar.tsx
@@ -1,5 +1,7 @@
+import type { JSX } from 'react'
 import { AppShell, Burger, Button, Flex } from '@mantine/core'
 import { Link, useRouter } from 'tuono'
+
 import Actions from './actions'
 
 interface NavbarProps {

--- a/apps/documentation/src/components/navigation-buttons/navigation-buttons.tsx
+++ b/apps/documentation/src/components/navigation-buttons/navigation-buttons.tsx
@@ -1,3 +1,4 @@
+import type { JSX } from 'react'
 import { Box, Button, Text, Title, Flex } from '@mantine/core'
 import { Link } from 'tuono'
 import { IconArrowRight, IconArrowLeft } from '@tabler/icons-react'

--- a/apps/documentation/src/components/sidebar/sidebar-link.tsx
+++ b/apps/documentation/src/components/sidebar/sidebar-link.tsx
@@ -1,5 +1,6 @@
+import type { JSX, ReactNode } from 'react'
+import { useState } from 'react'
 import { NavLink, type NavLinkProps } from '@mantine/core'
-import { useState, type ReactNode } from 'react'
 import { Link, useRouter } from 'tuono'
 import { IconChevronRight } from '@tabler/icons-react'
 

--- a/apps/documentation/src/components/sidebar/sidebar.tsx
+++ b/apps/documentation/src/components/sidebar/sidebar.tsx
@@ -1,4 +1,6 @@
+import type { JSX } from 'react'
 import { AppShell } from '@mantine/core'
+
 import SidebarLink from './sidebar-link'
 
 export default function Sidebar({ close }: { close: () => void }): JSX.Element {

--- a/apps/documentation/src/components/table-of-content/table-of-content.tsx
+++ b/apps/documentation/src/components/table-of-content/table-of-content.tsx
@@ -1,6 +1,7 @@
 /*
  * Component inspired by: https://github.com/mantinedev/mantine/tree/master/apps/mantine.dev/src/components/TableOfContents
  */
+import type { JSX } from 'react'
 import { useEffect, useRef, useState } from 'react'
 import { useRouter, Link } from 'tuono'
 import { IconList } from '@tabler/icons-react'

--- a/apps/documentation/src/components/theme-btn/theme-btn.tsx
+++ b/apps/documentation/src/components/theme-btn/theme-btn.tsx
@@ -1,3 +1,4 @@
+import type { JSX } from 'react'
 import {
   ActionIcon,
   useMantineColorScheme,

--- a/apps/documentation/src/routes/__root.tsx
+++ b/apps/documentation/src/routes/__root.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import type { ReactNode, JSX } from 'react'
 import {
   ColorSchemeScript,
   createTheme,

--- a/apps/documentation/src/routes/documentation/__root.tsx
+++ b/apps/documentation/src/routes/documentation/__root.tsx
@@ -1,5 +1,6 @@
-import type { ReactNode } from 'react'
+import type { ReactNode, JSX } from 'react'
 import { AppShell, Container } from '@mantine/core'
+
 import MdxProvider from '../../components/mdx-provider'
 import EditPage from '../../components/edit-page'
 

--- a/apps/documentation/src/routes/documentation/tutorial/api-fetching.mdx
+++ b/apps/documentation/src/routes/documentation/tutorial/api-fetching.mdx
@@ -64,6 +64,7 @@ Now the Pokémon are correctly fetched and hydrated on the client side, so we ca
 
 ```tsx
 // src/routes/index.tsx
+import type { JSX } from 'react'
 import type { TuonoProps } from 'tuono'
 
 interface Pokemon {
@@ -76,9 +77,9 @@ interface IndexProps {
 
 export default function IndexPage({
   data,
-}: TuonoProps<IndexProps>): JSX.Element {
+}: TuonoProps<IndexProps>): JSX.Element | null {
   if (!data?.results) {
-    return <></>
+    return null
   }
 
   return (

--- a/apps/documentation/src/routes/documentation/tutorial/components.mdx
+++ b/apps/documentation/src/routes/documentation/tutorial/components.mdx
@@ -25,6 +25,7 @@ Create the following file `src/components/PokemonLink.tsx` and fill the content 
 
 ```tsx
 // src/components/PokemonLink.tsx
+import type { JSX } from 'react'
 import { Link } from 'tuono'
 
 interface Pokemon {
@@ -109,8 +110,9 @@ Then import the styles into the `PokemonLink` component as following:
 
 ```diff
 // src/components/PokemonLink.tsx
-import { Link } from "tuono";
-import type { Pokemon } from "./../types/pokemon";
+import type { JSX } from 'react'
+import { Link } from "tuono"
+import type { Pokemon } from "./../types/pokemon"
 ++ import styles from './PokemonLink.module.css'
 
 export default function PokemonLink({

--- a/apps/documentation/src/routes/documentation/tutorial/dynamic-routes.mdx
+++ b/apps/documentation/src/routes/documentation/tutorial/dynamic-routes.mdx
@@ -63,6 +63,7 @@ async fn get_pokemon(req: Request, fetch: Client) -> Response {
 Then let’s work on the frontend. Paste into the `[pokemon].tsx` file the following code:
 
 ```tsx
+import type { JSX } from 'react'
 import { TuonoProps } from 'tuono'
 import PokemonView from '../../components/PokemonView'
 

--- a/apps/documentation/src/routes/documentation/tutorial/seo.mdx
+++ b/apps/documentation/src/routes/documentation/tutorial/seo.mdx
@@ -26,6 +26,7 @@ To do so `tuono` also exposes the `<Head />` component useful exactly for handli
 
 ```diff
 // src/routes/index.tsx
+import type { JSX } from 'react'
 import type { TuonoProps } from "tuono";
 ++ import { Head } from "tuono"
 
@@ -80,6 +81,7 @@ export default function IndexPage({
 
 ```diff
 // src/routes/pokemons/[pokemon].tsx
+import type { JSX } from 'react'
 -- import { TuonoProps } from "tuono";
 ++ import { TuonoProps, Head } from "tuono";
 import PokemonView from "../../components/PokemonView";

--- a/apps/documentation/src/routes/index.tsx
+++ b/apps/documentation/src/routes/index.tsx
@@ -1,3 +1,5 @@
+import type { JSX } from 'react'
+
 import Hero from '../components/hero'
 import MetaTags from '../components/meta-tags'
 

--- a/examples/mdx/src/routes/__root.tsx
+++ b/examples/mdx/src/routes/__root.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import type { ReactNode, JSX } from 'react'
 import { MDXProvider } from '@mdx-js/react'
 
 interface RootRouteProps {

--- a/examples/tuono/src/routes/__root.tsx
+++ b/examples/tuono/src/routes/__root.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import type { ReactNode, JSX } from 'react'
 
 interface RootRouteProps {
   children: ReactNode

--- a/examples/tuono/src/routes/index.tsx
+++ b/examples/tuono/src/routes/index.tsx
@@ -1,3 +1,4 @@
+import type { JSX } from 'react'
 import type { TuonoProps } from 'tuono'
 
 interface IndexProps {

--- a/examples/tutorial/src/components/PokemonLink.tsx
+++ b/examples/tutorial/src/components/PokemonLink.tsx
@@ -1,4 +1,6 @@
+import type { JSX } from 'react'
 import { Link } from 'tuono'
+
 import styles from './PokemonLink.module.css'
 
 interface Pokemon {

--- a/examples/tutorial/src/routes/__root.tsx
+++ b/examples/tutorial/src/routes/__root.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import type { ReactNode, JSX } from 'react'
 
 interface RootRouteProps {
   children: ReactNode

--- a/examples/tutorial/src/routes/index.tsx
+++ b/examples/tutorial/src/routes/index.tsx
@@ -1,5 +1,7 @@
 // src/routes/index.tsx
+import type { JSX } from 'react'
 import { Head, type TuonoProps } from 'tuono'
+
 import PokemonLink from '../components/PokemonLink'
 
 interface Pokemon {
@@ -12,9 +14,9 @@ interface IndexProps {
 
 export default function IndexPage({
   data,
-}: TuonoProps<IndexProps>): JSX.Element {
+}: TuonoProps<IndexProps>): JSX.Element | null {
   if (!data?.results) {
-    return <></>
+    return null
   }
 
   return (

--- a/examples/tutorial/src/routes/pokemons/[pokemon].tsx
+++ b/examples/tutorial/src/routes/pokemons/[pokemon].tsx
@@ -1,22 +1,24 @@
+import type { JSX } from 'react'
 import { Head, type TuonoProps } from 'tuono'
+
 import PokemonView from '../../components/PokemonView'
 
 interface Pokemon {
-	name: string
-	id: string
-	weight: number
-	height: number
+  name: string
+  id: string
+  weight: number
+  height: number
 }
 
 export default function PokemonPage({
-	data,
+  data,
 }: TuonoProps<Pokemon>): JSX.Element {
-	return (
-		<>
-			<Head>
-				<title>{`Pokemon: ${data?.name}`}</title>
-			</Head>
-			<PokemonView pokemon={data} />
-		</>
-	)
+  return (
+    <>
+      <Head>
+        <title>{`Pokemon: ${data?.name}`}</title>
+      </Head>
+      <PokemonView pokemon={data} />
+    </>
+  )
 }

--- a/packages/router/src/components/Link.tsx
+++ b/packages/router/src/components/Link.tsx
@@ -17,7 +17,7 @@ interface TuonoLinkProps {
 
 export default function Link(
   componentProps: AnchorHTMLAttributes<HTMLAnchorElement> & TuonoLinkProps,
-): JSX.Element {
+): React.JSX.Element {
   const { preload = true, scroll = true, ...props } = componentProps
   const router = useRouter()
   const route = useRoute(props.href)

--- a/packages/router/src/components/Matches.tsx
+++ b/packages/router/src/components/Matches.tsx
@@ -9,7 +9,7 @@ interface MatchesProps {
   serverSideProps: any
 }
 
-export function Matches({ serverSideProps }: MatchesProps): JSX.Element {
+export function Matches({ serverSideProps }: MatchesProps): React.JSX.Element {
   const location = useRouterStore((st) => st.location)
 
   const route = useRoute(location.pathname)

--- a/packages/router/src/components/NotFound.tsx
+++ b/packages/router/src/components/NotFound.tsx
@@ -3,7 +3,7 @@ import { RouteMatch } from './RouteMatch'
 import Link from './Link'
 import { useInternalRouter } from '../hooks/useInternalRouter'
 
-export default function NotFound(): JSX.Element {
+export default function NotFound(): React.JSX.Element {
   const router = useInternalRouter()
 
   const custom404Route = router.routesById['/404']

--- a/packages/router/src/components/RouteMatch.tsx
+++ b/packages/router/src/components/RouteMatch.tsx
@@ -16,7 +16,7 @@ interface MatchProps {
 export const RouteMatch = ({
   route,
   serverSideProps,
-}: MatchProps): JSX.Element => {
+}: MatchProps): React.JSX.Element => {
   const { data, isLoading } = useServerSideProps(route, serverSideProps)
 
   const routes = React.useMemo(() => loadParentComponents(route), [route.id])
@@ -55,13 +55,13 @@ const TraverseRootComponents = React.memo(
     isLoading,
     index = 0,
     children,
-  }: TraverseRootComponentsProps): JSX.Element => {
+  }: TraverseRootComponentsProps): React.JSX.Element => {
     if (routes.length > index) {
       const Parent = React.useMemo(
         () =>
           routes[index]?.component as unknown as (
             props: ParentProps,
-          ) => JSX.Element,
+          ) => React.JSX.Element,
         [],
       )
 

--- a/packages/router/src/components/RouterProvider.tsx
+++ b/packages/router/src/components/RouterProvider.tsx
@@ -1,9 +1,10 @@
-import { getRouterContext } from './RouterContext'
-import { Matches } from './Matches'
+import React from 'react'
+import type { ReactNode, JSX } from 'react'
 import { useListenBrowserUrlUpdates } from '../hooks/useListenBrowserUrlUpdates'
-import React, { type ReactNode } from 'react'
 import { initRouterStore } from '../hooks/useRouterStore'
 import type { ServerProps } from '../types'
+import { getRouterContext } from './RouterContext'
+import { Matches } from './Matches'
 
 type Router = any
 

--- a/packages/router/src/dynamic.tsx
+++ b/packages/router/src/dynamic.tsx
@@ -13,7 +13,7 @@ type ImportFn = () => Promise<{ default: React.ComponentType<any> }>
  * It can be wrapped within a React.Suspense component in order to handle its loading state.
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const dynamic = (importFn: ImportFn): JSX.Element => {
+export const dynamic = (importFn: ImportFn): React.JSX.Element => {
   /**
    *
    * This function is just a placeholder. The real work is done by the bundler.

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -1,3 +1,5 @@
+import type { JSX } from 'react'
+
 import { trimPath, trimPathRight } from './utils'
 import type { Route } from './route'
 


### PR DESCRIPTION
## Context & Description

Close #84.

I remove all the usage of global `JSX` I was able to find and replaced them with the one included inside `React`.

> [!NOTE]
> I used typed named imports for it unless there there was already a `import * as React from 'react'`, 
> in that case I used `React.JSX` instead of adding another import.

### Additional related changes 

- I reaplaced few empty fragments (`<></>`) with `null`
- I enabled [`@typescript-eslint/no-deprecated`](https://typescript-eslint.io/rules/no-deprecated/) rule which can report when using `@deprecated` items

---

While working on this I got a few ideas about some improvements to repository maintenance and DX.
I'll open separate issue to discuss them later this week.