### PR TITLE
Create logger service

### DIFF
--- a/crates/tuono/Cargo.toml
+++ b/crates/tuono/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuono"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 authors = ["V. Ageno <valerioageno@yahoo.it>"]
 description = "The react/rust fullstack framework"

--- a/crates/tuono_lib/Cargo.toml
+++ b/crates/tuono_lib/Cargo.toml
@@ -38,4 +38,7 @@ tuono_lib_macros = {path = "../tuono_lib_macros", version = "0.12.0"}
 tokio-tungstenite = "0.24.0"
 futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
 tungstenite = "0.24.0"
+http = "1.1.0"
+pin-project = "1.1.7"
+tower = "0.5.1"
 

--- a/crates/tuono_lib/Cargo.toml
+++ b/crates/tuono_lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuono_lib"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 authors = ["V. Ageno <valerioageno@yahoo.it>"]
 description = "The react/rust fullstack framework"
@@ -33,7 +33,7 @@ either = "1.13.0"
 tower-http = {version = "0.6.0", features = ["fs"]}
 colored = "2.1.0"
 
-tuono_lib_macros = {path = "../tuono_lib_macros", version = "0.12.0"}
+tuono_lib_macros = {path = "../tuono_lib_macros", version = "0.12.1"}
 # Match the same version used by axum
 tokio-tungstenite = "0.24.0"
 futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }

--- a/crates/tuono_lib/src/catch_all.rs
+++ b/crates/tuono_lib/src/catch_all.rs
@@ -1,15 +1,12 @@
 use crate::{ssr::Js, Payload};
 use axum::extract::{Path, Request};
 use axum::response::Html;
-use colored::*;
 use std::collections::HashMap;
-use tokio::time::Instant;
 
 pub async fn catch_all(
     Path(params): Path<HashMap<String, String>>,
     request: Request,
 ) -> Html<String> {
-    let start = Instant::now();
     let pathname = request.uri();
     let headers = request.headers();
 
@@ -19,18 +16,6 @@ pub async fn catch_all(
     let payload = Payload::new(&req, &"").client_payload().unwrap();
 
     let result = Js::render_to_string(Some(&payload));
-
-    let duration = start.elapsed();
-
-    // TODO: handle 404 error on catch_all route
-    let http_code = "200";
-
-    println!(
-        "  GET {} {} in {}ms",
-        req.uri.path(),
-        http_code.green(),
-        duration.as_millis()
-    );
 
     match result {
         Ok(html) => Html(html),

--- a/crates/tuono_lib/src/lib.rs
+++ b/crates/tuono_lib/src/lib.rs
@@ -5,6 +5,7 @@ mod payload;
 mod request;
 mod response;
 mod server;
+mod services;
 mod ssr;
 mod vite_reverse_proxy;
 mod vite_websocket_proxy;

--- a/crates/tuono_lib/src/response.rs
+++ b/crates/tuono_lib/src/response.rs
@@ -3,9 +3,7 @@ use crate::{ssr::Js, Payload};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::{Html, IntoResponse, Redirect};
 use axum::Json;
-use colored::*;
 use erased_serde::Serialize;
-use tokio::time::Instant;
 
 pub struct Props {
     data: Box<dyn Serialize>,
@@ -74,25 +72,13 @@ impl Response {
     pub fn render_to_string(&self, req: Request) -> impl IntoResponse {
         match self {
             Self::Props(Props { data, http_code }) => {
-                let start = Instant::now();
                 let payload = Payload::new(&req, data).client_payload().unwrap();
 
-                let response = match Js::render_to_string(Some(&payload)) {
+                match Js::render_to_string(Some(&payload)) {
                     Ok(html) => (*http_code, Html(html)),
                     Err(_) => (*http_code, Html("500 Internal server error".to_string())),
                 }
-                .into_response();
-
-                let duration = start.elapsed();
-
-                println!(
-                    "  GET {} {} in {}ms",
-                    req.uri.path(),
-                    http_code.as_str().green(),
-                    duration.as_millis()
-                );
-
-                response
+                .into_response()
             }
             Self::Redirect(to) => Redirect::permanent(to).into_response(),
             Self::Custom(response) => response.clone().into_response(),

--- a/crates/tuono_lib/src/server.rs
+++ b/crates/tuono_lib/src/server.rs
@@ -45,7 +45,10 @@ impl Server {
                 .layer(LoggerLayer::new())
                 .route("/vite-server/", get(vite_websocket_proxy))
                 .route("/vite-server/*path", get(vite_reverse_proxy))
-                .fallback_service(ServeDir::new(DEV_PUBLIC_DIR).fallback(get(catch_all)))
+                .fallback_service(
+                    ServeDir::new(DEV_PUBLIC_DIR)
+                        .fallback(get(catch_all).layer(LoggerLayer::new())),
+                )
                 .with_state(fetch);
 
             axum::serve(listener, router)
@@ -60,7 +63,10 @@ impl Server {
                 .router
                 .to_owned()
                 .layer(LoggerLayer::new())
-                .fallback_service(ServeDir::new(PROD_PUBLIC_DIR).fallback(get(catch_all)))
+                .fallback_service(
+                    ServeDir::new(PROD_PUBLIC_DIR)
+                        .fallback(get(catch_all).layer(LoggerLayer::new())),
+                )
                 .with_state(fetch);
 
             axum::serve(listener, router)

--- a/crates/tuono_lib/src/server.rs
+++ b/crates/tuono_lib/src/server.rs
@@ -1,6 +1,6 @@
-use crate::mode::{Mode, GLOBAL_MODE};
-
 use crate::manifest::load_manifest;
+use crate::mode::{Mode, GLOBAL_MODE};
+use crate::services::logger::LoggerLayer;
 use axum::routing::{get, Router};
 use colored::Colorize;
 use ssr_rs::Ssr;
@@ -42,6 +42,7 @@ impl Server {
             let router = self
                 .router
                 .to_owned()
+                .layer(LoggerLayer::new())
                 .route("/vite-server/", get(vite_websocket_proxy))
                 .route("/vite-server/*path", get(vite_reverse_proxy))
                 .fallback_service(ServeDir::new(DEV_PUBLIC_DIR).fallback(get(catch_all)))
@@ -58,6 +59,7 @@ impl Server {
             let router = self
                 .router
                 .to_owned()
+                .layer(LoggerLayer::new())
                 .fallback_service(ServeDir::new(PROD_PUBLIC_DIR).fallback(get(catch_all)))
                 .with_state(fetch);
 

--- a/crates/tuono_lib/src/services.rs
+++ b/crates/tuono_lib/src/services.rs
@@ -1,0 +1,1 @@
+pub mod logger;

--- a/crates/tuono_lib/src/services/logger.rs
+++ b/crates/tuono_lib/src/services/logger.rs
@@ -1,8 +1,5 @@
 use colored::Colorize;
-use http::method::Method;
-
-use axum::http::Request;
-use http::Response;
+use http::{method::Method, Request, Response};
 use pin_project::pin_project;
 use std::fmt::Debug;
 use std::future::Future;
@@ -89,6 +86,10 @@ where
             Poll::Ready(res) => res,
             Poll::Pending => return Poll::Pending,
         };
+
+        if this.path.starts_with("/__tuono/data") {
+            return Poll::Ready(res);
+        }
 
         let status_code = res.as_ref().unwrap().status();
 

--- a/crates/tuono_lib/src/services/logger.rs
+++ b/crates/tuono_lib/src/services/logger.rs
@@ -1,0 +1,105 @@
+use colored::Colorize;
+use http::method::Method;
+
+use axum::http::Request;
+use http::Response;
+use pin_project::pin_project;
+use std::fmt::Debug;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::time::Instant;
+use tower::{Layer, Service};
+
+#[derive(Clone)]
+pub struct LoggerLayer {}
+
+impl LoggerLayer {
+    pub fn new() -> Self {
+        LoggerLayer {}
+    }
+}
+
+impl<S> Layer<S> for LoggerLayer {
+    type Service = Logger<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        Logger::new(inner)
+    }
+}
+
+#[derive(Clone)]
+pub struct Logger<S> {
+    inner: S,
+}
+
+impl<S> Logger<S> {
+    pub fn new(inner: S) -> Self {
+        Logger { inner }
+    }
+}
+
+impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for Logger<S>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>>,
+    ResBody: Default,
+    <S as Service<Request<ReqBody>>>::Error: Debug,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = LoggerFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        let method = req.method().clone();
+        let path = req.uri().path().to_string();
+
+        LoggerFuture {
+            future: self.inner.call(req),
+            method,
+            path,
+            start: Instant::now(),
+        }
+    }
+}
+
+#[pin_project]
+pub struct LoggerFuture<F> {
+    #[pin]
+    future: F,
+    method: Method,
+    path: String,
+    start: Instant,
+}
+
+impl<F, B, E> Future for LoggerFuture<F>
+where
+    F: Future<Output = Result<Response<B>, E>>,
+    B: Default,
+    E: Debug,
+{
+    type Output = Result<Response<B>, E>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let res: F::Output = match this.future.poll(cx) {
+            Poll::Ready(res) => res,
+            Poll::Pending => return Poll::Pending,
+        };
+
+        let status_code = res.as_ref().unwrap().status();
+
+        println!(
+            "  {} {} {} in {}ms",
+            this.method,
+            this.path,
+            status_code.as_str().green(),
+            this.start.elapsed().as_millis()
+        );
+
+        Poll::Ready(res)
+    }
+}

--- a/crates/tuono_lib_macros/Cargo.toml
+++ b/crates/tuono_lib_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuono_lib_macros"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 description = "The react/rust fullstack framework"
 keywords = [ "react", "typescript", "fullstack", "web", "ssr"]

--- a/packages/fs-router-vite-plugin/package.json
+++ b/packages/fs-router-vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tuono-fs-router-vite-plugin",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Plugin for the tuono's file system router. Tuono is the react/rust fullstack framework",
   "scripts": {
     "dev": "vite build --watch",

--- a/packages/lazy-fn-vite-plugin/package.json
+++ b/packages/lazy-fn-vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tuono-lazy-fn-vite-plugin",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Plugin for the tuono's lazy fn. Tuono is the react/rust fullstack framework",
   "scripts": {
     "dev": "vite build --watch",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tuono-router",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "React routing component for the framework tuono. Tuono is the react/rust fullstack framework",
   "scripts": {
     "dev": "vite build --watch",

--- a/packages/tuono/package.json
+++ b/packages/tuono/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tuono",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "The react/rust fullstack framework",
   "scripts": {
     "dev": "vite build --watch",


### PR DESCRIPTION
## Context & Description

<!--
Thank you for your Pull Request. 

Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/Valerioageno/tuono/blob/main/CONTRIBUTING.md
-->

This PR is the first step about improving the current server setup by leveraging [tower](https://github.com/tower-rs/tower)'s services. 

> These changes will eventually enable tuono to leverage a plugin system for developing custom libraries on top of tower.

Here specifically I created a logger services that exactly matches the output of the previous logger. Since this is a service (so it wraps the whole HTTP request) the logger takes into account the whole request timing rather than just the time spent by tuono to execute the server side rendering.

> Note: right now it logs all the user defined endpoint requests (vite and catch_all excluded). This means that the client side routing API endpoints are logged (which I think they shouldn't). The next PR will update the routing system so I'll opt out for the CSR endpoints and I'll re-enable the catch_all routes.