### PR TITLE
fix: handle hyphen in route

### DIFF
--- a/crates/tuono/src/app.rs
+++ b/crates/tuono/src/app.rs
@@ -119,6 +119,8 @@ mod tests {
             "/home/user/Documents/tuono/src/routes/index.rs",
             "/home/user/Documents/tuono/src/routes/posts/index.rs",
             "/home/user/Documents/tuono/src/routes/posts/[post].rs",
+            "/home/user/Documents/tuono/src/routes/posts/handle-this.rs",
+            "/home/user/Documents/tuono/src/routes/posts/handle-this/[post].rs",
             "/home/user/Documents/tuono/src/routes/posts/UPPERCASE.rs",
             "/home/user/Documents/tuono/src/routes/sitemap.xml.rs",
         ];
@@ -132,6 +134,8 @@ mod tests {
             ("/about", "about"),
             ("/posts/index", "posts_index"),
             ("/posts/[post]", "posts_dyn_post"),
+            ("/posts/handle-this", "posts_handle_hyphen_this"),
+            ("/posts/handle-this/[post]", "posts_handle_hyphen_this_dyn_post"),
             ("/posts/UPPERCASE", "posts_uppercase"),
             ("/sitemap.xml", "sitemap_dot_xml"),
         ];

--- a/crates/tuono/src/app.rs
+++ b/crates/tuono/src/app.rs
@@ -135,7 +135,10 @@ mod tests {
             ("/posts/index", "posts_index"),
             ("/posts/[post]", "posts_dyn_post"),
             ("/posts/handle-this", "posts_handle_hyphen_this"),
-            ("/posts/handle-this/[post]", "posts_handle_hyphen_this_dyn_post"),
+            (
+                "/posts/handle-this/[post]",
+                "posts_handle_hyphen_this_dyn_post",
+            ),
             ("/posts/UPPERCASE", "posts_uppercase"),
             ("/sitemap.xml", "sitemap_dot_xml"),
         ];

--- a/crates/tuono/src/route.rs
+++ b/crates/tuono/src/route.rs
@@ -30,8 +30,9 @@ impl AxumInfo {
         let module_import = module
             .as_str()
             .to_string()
-            .replace(['/', '-'], "_")
+            .replace('/', "_")
             .replace('.', "_dot_")
+            .replace('-', "_hyphen_")
             .to_lowercase();
 
         if axum_route.is_empty() {
@@ -46,7 +47,8 @@ impl AxumInfo {
                 module_import: module
                     .as_str()
                     .to_string()
-                    .replace(['/', '-'], "_")
+                    .replace('/', "_")
+                    .replace('-', "_hyphen_")
                     .replace('[', "dyn_")
                     .replace(']', ""),
                 axum_route: axum_route.replace('[', ":").replace(']', ""),
@@ -184,19 +186,6 @@ mod tests {
 
         assert_eq!(dyn_info.axum_route, "/:posts");
         assert_eq!(dyn_info.module_import, "dyn_posts");
-    }
-
-    #[test]
-    fn should_handle_hyphen() {
-        let info = AxumInfo::new("/a-hyphen/index".to_string());
-
-        assert_eq!(info.axum_route, "/a-hyphen");
-        assert_eq!(info.module_import, "a_hyphen_index");
-
-        let dyn_info = AxumInfo::new("/a-hyphen/[posts]".to_string());
-
-        assert_eq!(dyn_info.axum_route, "/a-hyphen/:posts");
-        assert_eq!(dyn_info.module_import, "a_hyphen_dyn_posts");
     }
 
     #[test]

--- a/crates/tuono/src/route.rs
+++ b/crates/tuono/src/route.rs
@@ -30,9 +30,8 @@ impl AxumInfo {
         let module_import = module
             .as_str()
             .to_string()
-            .replace('/', "_")
+            .replace(['/', '-'], "_")
             .replace('.', "_dot_")
-            .replace('-', "_")
             .to_lowercase();
 
         if axum_route.is_empty() {
@@ -47,8 +46,7 @@ impl AxumInfo {
                 module_import: module
                     .as_str()
                     .to_string()
-                    .replace('/', "_")
-                    .replace('-', "_")
+                    .replace(['/', '-'], "_")
                     .replace('[', "dyn_")
                     .replace(']', ""),
                 axum_route: axum_route.replace('[', ":").replace(']', ""),

--- a/crates/tuono/src/route.rs
+++ b/crates/tuono/src/route.rs
@@ -32,6 +32,7 @@ impl AxumInfo {
             .to_string()
             .replace('/', "_")
             .replace('.', "_dot_")
+            .replace('-', "_")
             .to_lowercase();
 
         if axum_route.is_empty() {
@@ -47,6 +48,7 @@ impl AxumInfo {
                     .as_str()
                     .to_string()
                     .replace('/', "_")
+                    .replace('-', "_")
                     .replace('[', "dyn_")
                     .replace(']', ""),
                 axum_route: axum_route.replace('[', ":").replace(']', ""),
@@ -184,6 +186,19 @@ mod tests {
 
         assert_eq!(dyn_info.axum_route, "/:posts");
         assert_eq!(dyn_info.module_import, "dyn_posts");
+    }
+
+    #[test]
+    fn should_handle_hyphen() {
+        let info = AxumInfo::new("/a-hyphen/index".to_string());
+
+        assert_eq!(info.axum_route, "/a-hyphen");
+        assert_eq!(info.module_import, "a_hyphen_index");
+
+        let dyn_info = AxumInfo::new("/a-hyphen/[posts]".to_string());
+
+        assert_eq!(dyn_info.axum_route, "/a-hyphen/:posts");
+        assert_eq!(dyn_info.module_import, "a_hyphen_dyn_posts");
     }
 
     #[test]


### PR DESCRIPTION
## Context & Description

I got this exception when trying to use a hyphen in route. e.g. 

```
src/routes/openid-conntect/index.rs
```

<img width="501" alt="Screenshot 2024-11-16 at 13 45 17" src="https://github.com/user-attachments/assets/24b670ed-6d38-4a23-8969-b70f420c0df8">

assuming the fix it to replacing `-` to `_` that makes compiler happy.