### PR TITLE
Update watchexec to v5 and watchexec-signals to v4

### DIFF
--- a/crates/tuono/Cargo.toml
+++ b/crates/tuono/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/lib.rs"
 
 [dependencies]
 clap = { version = "4.5.4", features = ["derive", "cargo"] }
-watchexec = "4.0.0"
+watchexec = "5.0.0"
 miette = "7.2.0"
 watchexec-signals = "3.0.0"
 tokio = { version = "1", features = ["full"] }

--- a/crates/tuono/Cargo.toml
+++ b/crates/tuono/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/lib.rs"
 clap = { version = "4.5.4", features = ["derive", "cargo"] }
 watchexec = "5.0.0"
 miette = "7.2.0"
-watchexec-signals = "3.0.0"
+watchexec-signals = "4.0.0"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0.202", features = ["derive"] }
 watchexec-supervisor = "3.0.0"

--- a/crates/tuono/src/watch.rs
+++ b/crates/tuono/src/watch.rs
@@ -3,8 +3,8 @@ use watchexec_supervisor::command::{Command, Program};
 
 use miette::{IntoDiagnostic, Result};
 use watchexec::Watchexec;
+use watchexec_signals::Signal;
 use watchexec_supervisor::job::{start_job, Job};
-use watchexec_supervisor::Signal;
 
 use crate::mode::Mode;
 use crate::source_builder::bundle_axum_source;

--- a/crates/tuono/src/watch.rs
+++ b/crates/tuono/src/watch.rs
@@ -3,8 +3,8 @@ use watchexec_supervisor::command::{Command, Program};
 
 use miette::{IntoDiagnostic, Result};
 use watchexec::Watchexec;
-use watchexec_signals::Signal;
 use watchexec_supervisor::job::{start_job, Job};
+use watchexec_supervisor::Signal;
 
 use crate::mode::Mode;
 use crate::source_builder::bundle_axum_source;


### PR DESCRIPTION
Related to Issue #34 

Previously updating watchexec to v5 leads to this error:

```
error[E0308]: mismatched types
  --> crates/tuono/src/watch.rs:90:46
   |
90 |         if action.signals().any(|sig| sig == Signal::Interrupt) {
   |                                       ---    ^^^^^^^^^^^^^^^^^ expected `watchexec_supervisor::Signal`, found `watchexec_signals::Signal`
```

This PR fixes the import issue by changing `use watchexec-signals::Signal` to `use watchexec_supervisor::Signal`.

It also updates watchexec-signals to v4 with no further errors.