### PR TITLE
refactor: replace () => JSX.Element with `React.ComponentType`

### DIFF
--- a/apps/documentation/src/components/sidebar/sidebar.tsx
+++ b/apps/documentation/src/components/sidebar/sidebar.tsx
@@ -3,7 +3,11 @@ import { AppShell } from '@mantine/core'
 
 import SidebarLink from './sidebar-link'
 
-export default function Sidebar({ close }: { close: () => void }): JSX.Element {
+interface SidebarProps {
+  close: () => void
+}
+
+export default function Sidebar({ close }: SidebarProps): JSX.Element {
   return (
     <AppShell.Navbar p="md">
       <SidebarLink

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -1,4 +1,4 @@
-import type { JSX } from 'react'
+import type { ComponentType as ReactComponentType } from 'react'
 
 import { trimPath, trimPathRight } from './utils'
 import type { Route } from './route'
@@ -12,7 +12,7 @@ interface CreateRouter {
 }
 
 interface RouteOptions {
-  component?: () => JSX.Element
+  component?: ReactComponentType
   hasHandler?: boolean
   routeTree?: RouteTree
 }

--- a/packages/router/src/types.ts
+++ b/packages/router/src/types.ts
@@ -1,3 +1,5 @@
+import type { ComponentType as ReactComponentType } from 'react'
+
 export interface Segment {
   type: 'pathname' | 'param' | 'wildcard'
   value: string
@@ -17,6 +19,6 @@ export interface RouteProps {
   isLoading: boolean
 }
 
-export type RouteComponent = ((props: RouteProps) => JSX.Element) & {
+export type RouteComponent = ReactComponentType<RouteProps> & {
   preload: () => void
 }


### PR DESCRIPTION
## Context & Description

Few types change related to [ReactNode vs JSX.Element Discord thread](https://discord.com/channels/1307411506735874208/1307729152417337364)

<!--
Thank you for your Pull Request.

Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/Valerioageno/tuono/blob/main/CONTRIBUTING.md
-->
