### PR TITLE
Better error handling for target ports conflict

### DIFF
--- a/crates/tuono_lib/src/server.rs
+++ b/crates/tuono_lib/src/server.rs
@@ -32,16 +32,37 @@ impl Server {
     }
 
     pub async fn start(&self) {
-        let addr = "0.0.0.0:3000";
-        let listener = match tokio::net::TcpListener::bind(addr).await {
-            Ok(listener) => listener,
-            Err(e) => {
-                eprintln!("\n  Error: Failed to bind to address {}. {}", addr, e);
-                eprintln!("  Please ensure that port 3000 is not already in use by another process or application.");
-                std::process::exit(1);
-            }
-        };
+        let rust_addr = "0.0.0.0:3000";
+        let vite_addr = "0.0.0.0:3001";
 
+        // Get the port from the address to be displayed in the console
+        let rust_port = rust_addr.split(":")
+            .last()
+            .unwrap_or("unknown");
+        let vite_port = vite_addr.split(":")
+            .last()
+            .unwrap_or("unknown");
+
+        let rust_listener = tokio::net::TcpListener::bind(rust_addr).await;
+        let vite_listener = tokio::net::TcpListener::bind(vite_addr).await;
+
+        match (rust_listener, vite_listener) {
+            (Ok(rust_listener), Ok(_vite_listener)) => {
+                println!("\n  Using port {} for Rust server.", rust_port.bold());
+                println!("  Using port {} for Vite server.", vite_port.bold());
+
+                self.serve(rust_listener).await;
+            }
+            (Err(_listener), _) | (_, Err(_listener)) => {
+                eprintln!("\n  Error: Failed to bind to either port {} or port {}.", rust_port, vite_port);
+                eprintln!("  Please ensure that ports {} and {} are not already in use by another process or application.", rust_port, vite_port);
+                
+                std::process::exit(1);
+            }                            
+        }
+    }
+
+    pub async fn serve(&self, listener: tokio::net::TcpListener) {
         if self.mode == Mode::Dev {
             println!("  Ready at: {}\n", "http://localhost:3000".blue().bold());
             let router = self

--- a/crates/tuono_lib/src/server.rs
+++ b/crates/tuono_lib/src/server.rs
@@ -13,6 +13,15 @@ use crate::{
 const DEV_PUBLIC_DIR: &str = "public";
 const PROD_PUBLIC_DIR: &str = "out/client";
 
+fn extract_port(addr: &str) -> &str {
+    addr.split(":")
+        .last()
+        .unwrap_or_else(|| {
+            eprintln!("  Error: Failed to extract port from address {}", addr);
+            std::process::exit(1);
+        })
+}
+
 pub struct Server {
     router: Router,
     mode: Mode,
@@ -36,12 +45,8 @@ impl Server {
         let vite_addr = "0.0.0.0:3001";
 
         // Get the port from the address to be displayed in the console
-        let rust_port = rust_addr.split(":")
-            .last()
-            .unwrap_or("unknown");
-        let vite_port = vite_addr.split(":")
-            .last()
-            .unwrap_or("unknown");
+        let rust_port = extract_port(&rust_addr);
+        let vite_port = extract_port(&vite_addr);
 
         let rust_listener = tokio::net::TcpListener::bind(rust_addr).await;
         let vite_listener = tokio::net::TcpListener::bind(vite_addr).await;
@@ -56,7 +61,7 @@ impl Server {
             (Err(_listener), _) | (_, Err(_listener)) => {
                 eprintln!("\n  Error: Failed to bind to either port {} or port {}.", rust_port, vite_port);
                 eprintln!("  Please ensure that ports {} and {} are not already in use by another process or application.", rust_port, vite_port);
-                
+
                 std::process::exit(1);
             }                            
         }

--- a/crates/tuono_lib/src/server.rs
+++ b/crates/tuono_lib/src/server.rs
@@ -32,7 +32,15 @@ impl Server {
     }
 
     pub async fn start(&self) {
-        let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
+        let addr = "0.0.0.0:3000";
+        let listener = match tokio::net::TcpListener::bind(addr).await {
+            Ok(listener) => listener,
+            Err(e) => {
+                eprintln!("\n  Error: Failed to bind to address {}. {}", addr, e);
+                eprintln!("  Please ensure that port 3000 is not already in use by another process or application.");
+                std::process::exit(1);
+            }
+        };
 
         if self.mode == Mode::Dev {
             println!("  Ready at: {}\n", "http://localhost:3000".blue().bold());


### PR DESCRIPTION
Related to #123 

This PR adds better error handling in case one or both of the target ports are unavailable for use.

Previously the use of `unwrap()` causes tokio to panic if it cannot bind to port 3000, when the port is already being used by another process.

`let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();`

causes

```
file:///home/fourier/Documents/tutorial/node_modules/vite/dist/node/chunks/dep-CB_7IfJ-.js:45595
          reject(new Error(`Port ${port} is already in use`));
                 ^

Error: Port 3001 is already in use
    at Server.onError (file:///home/fourier/Documents/tutorial/node_modules/vite/dist/node/chunks/dep-CB_7IfJ-.js:45595:18)
    at Server.emit (node:events:518:28)
    at emitErrorNT (node:net:1943:8)
    at process.processTicksAndRejections (node:internal/process/task_queues:90:21)

Node.js v22.11.0
thread 'tokio-runtime-worker' panicked at /home/fourier/.cargo/registry/src/index.crates.io-6f17d22bba15001f/watchexec-supervisor-3.0.0/src/job/task.rs:54:17:
all branches are disabled and there is no else branch
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Now the output will simply be

```
  ⚡ Tuono v0.13.1

  Error: Failed to bind to either port 3000 or port 3001.
  Please ensure that ports 3000 and 3001 are not already in use by another process or application.
```