### PR TITLE
Better error handling when trying to overwrite an existing folder and using a non-existent template

### DIFF
--- a/crates/tuono/src/scaffold_project.rs
+++ b/crates/tuono/src/scaffold_project.rs
@@ -68,6 +68,10 @@ pub fn create_new_project(folder_name: Option<String>, template: Option<String>)
     }
 
     if folder != "." {
+        if Path::new(&folder).exists() {
+            eprintln!("Error: Directory '{folder}' already exists");
+            return;
+        }
         create_dir(&folder).unwrap();
     }
 

--- a/crates/tuono/src/scaffold_project.rs
+++ b/crates/tuono/src/scaffold_project.rs
@@ -63,14 +63,16 @@ pub fn create_new_project(folder_name: Option<String>, template: Option<String>)
         .collect::<Vec<&GithubFile>>();
 
     if new_project_files.is_empty() {
-        println!("Template not found: {template}");
-        return;
+        eprintln!("Error: Template '{template}' not found");
+        println!("Hint: you can view the available templates at https://github.com/Valerioageno/tuono/tree/main/examples");
+        std::process::exit(1);
     }
 
     if folder != "." {
         if Path::new(&folder).exists() {
             eprintln!("Error: Directory '{folder}' already exists");
-            return;
+            println!("Hint: you can scaffold a tuono project within an existing folder with 'cd {folder} && tuono new .'");
+            std::process::exit(1);
         }
         create_dir(&folder).unwrap();
     }


### PR DESCRIPTION
## Context & Description

This PR improves error handling for two cases:

- When attempting to overwrite an existing folder with `tuono new [existing_dir]`
- When attempting to use `tuono new` template flag with a non-existent template