### PR TITLE
docs(CONTRIBUTING): add “Local development”

### DIFF
--- a/apps/documentation/src/components/sidebar/sidebar.tsx
+++ b/apps/documentation/src/components/sidebar/sidebar.tsx
@@ -90,12 +90,19 @@ export default function Sidebar({ close }: SidebarProps): JSX.Element {
           onClick={close}
         />
       </SidebarLink>
+
       <SidebarLink
         label="Contributing"
         href="/documentation/contributing"
-        onClick={close}
         leftSection="✨"
-      />
+        onClick={close}
+      >
+        <SidebarLink
+          href="/documentation/contributing/local-development"
+          label="Local development"
+          onClick={close}
+        />
+      </SidebarLink>
     </AppShell.Navbar>
   )
 }

--- a/apps/documentation/src/routes/documentation/contributing/index.mdx
+++ b/apps/documentation/src/routes/documentation/contributing/index.mdx
@@ -29,7 +29,7 @@ To check what the knowledge requirements are for each domain, check the
 [requirements](#requirements) section below.
 
 Currently, I'm keeping a private dashboard to prioritize new features and bug fixes, but if you
-want to propose something, please open a new issue on Github or reach out to me using
+want to propose something, please open a new issue on GitHub or reach out to me using
 my email address [valerioageno@yahoo.it](mailto:valerioageno@yahoo.it). I'm also available
 on Twitter (X) DMs `@valerioageno`, [Linkedin](https://www.linkedin.com/in/valerioageno)
 and discord `@__v__v__`.

--- a/apps/documentation/src/routes/documentation/contributing/index.mdx
+++ b/apps/documentation/src/routes/documentation/contributing/index.mdx
@@ -1,0 +1,57 @@
+import MetaTags from '../../../components/meta-tags'
+
+<MetaTags
+  title="Tuono - Contributing"
+  canonical="https://tuono.dev/documentation/contributing"
+  description="The project is massive - if you like it, do consider contributing!"
+/>
+
+import Breadcrumbs, { Element } from '../../../components/breadcrumbs'
+
+<Breadcrumbs breadcrumbs={[{ label: '✨ Contributing' }]} />
+
+# Contributing
+
+## TL;DR
+
+The project is massive - if you like it, do consider contributing!
+
+## Getting started
+
+The `tuono` project can mostly be split into the following subdomains:
+
+- The CLI
+- The Rust backend
+- The React frontend
+- The documentation website (which is written with tuono 🚀)
+
+To check what the knowledge requirements are for each domain, check the
+[requirements](#requirements) section below.
+
+Currently, I'm keeping a private dashboard to prioritize new features and bug fixes, but if you
+want to propose something, please open a new issue on Github or reach out to me using
+my email address [valerioageno@yahoo.it](mailto:valerioageno@yahoo.it). I'm also available
+on Twitter (X) DMs `@valerioageno`, [Linkedin](https://www.linkedin.com/in/valerioageno)
+and discord `@__v__v__`.
+
+## Requirements
+
+It's not strictly required to know both React (& typescript) and Rust (even though it
+would be a great nice to have).
+
+Without taking into account specific cases, we can mostly split the domain requirements by:
+
+- The `CLI` needs Rust knowledge (even though a couple of scenarios might also need Typescript)
+- The Backend needs just `Rust`
+- The Frontend needs just `React` & `Typescript`
+- The documentation website needs just `React` & `Typescript` (or even less, since most of the
+  code is markdown).
+
+import NavigationButtons from '../../../components/navigation-buttons'
+
+<NavigationButtons
+  next={{
+    title: 'Local development',
+    href: '/documentation/contributing/local-development',
+  }}
+/>

--- a/apps/documentation/src/routes/documentation/contributing/local-development.mdx
+++ b/apps/documentation/src/routes/documentation/contributing/local-development.mdx
@@ -17,7 +17,7 @@ import Breadcrumbs, { Element } from '../../../components/breadcrumbs'
 
 # Local development
 
-Thanks for your interest! In this page you find the instructions to setup the `tuono`!
+Thanks for your interest! In this page, you find the instructions to set up the `tuono`!
 
 ## Quick setup
 
@@ -32,7 +32,7 @@ pnpm run check-all
 
 ### Fork and clone repository
 
-After [forking the repo on Github](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo):
+After [forking the repo on GitHub](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo):
 
 ```sh
 git clone https://github.com/<your-name-here>/tuono
@@ -44,7 +44,7 @@ cd tuono
 Install the Rust programming language tool chain (`rust` and `cargo`).
 Follows instructions in the official [docs](https://rustup.rs/)
 
-### NodeJS - runtime
+### NodeJS — runtime
 
 Install `NodeJS`.
 You can follow the instructions from the [Node official site](https://nodejs.org/en/download/package-manager)
@@ -59,7 +59,7 @@ You can follow the instructions from the [Node official site](https://nodejs.org
 >
 > to simply pickup the correct version!
 
-### NodeJS - package manager
+### NodeJS — package manager
 
 We use [`pnpm`](https://pnpm.io) as `NodeJS` package manager.
 
@@ -67,7 +67,7 @@ You can see which version of yarn we use by checking the `packageManager` field 
 
 ### Pre-flight checks
 
-To check that everting is working correctly run:
+Check that everything is working properly run:
 
 ```sh
 turbo run check-all
@@ -86,6 +86,12 @@ cargo build
 
    ```sh
    cargo build
+   ```
+
+   To automatically rebuild crates on code change, consider using `cargo-watch` crate
+
+   ```sh
+   cargo watch -x build -w crates/
    ```
 
 1. You can now use the binary inside `/target/debug/tuono` in another folder on your local machine

--- a/apps/documentation/src/routes/documentation/contributing/local-development.mdx
+++ b/apps/documentation/src/routes/documentation/contributing/local-development.mdx
@@ -8,7 +8,12 @@ import MetaTags from '../../../components/meta-tags'
 
 import Breadcrumbs, { Element } from '../../../components/breadcrumbs'
 
-<Breadcrumbs breadcrumbs={[{ label: '✨ Contributing' }]} />
+<Breadcrumbs
+  breadcrumbs={[
+    { label: '✨ Contributing', href: '/documentation/contributing' },
+    { label: 'Local development' },
+  ]}
+/>
 
 # Local development
 

--- a/apps/documentation/src/routes/documentation/contributing/local-development.mdx
+++ b/apps/documentation/src/routes/documentation/contributing/local-development.mdx
@@ -17,16 +17,7 @@ import Breadcrumbs, { Element } from '../../../components/breadcrumbs'
 
 # Local development
 
-Thanks for your interest! In this page, you find the instructions to set up the `tuono`!
-
-## Quick setup
-
-```sh
-git clone https://github.com/<your-name-here>/tuono
-cd tuono
-pnpm i
-pnpm run check-all
-```
+Thanks for your interest! In this page, you find the instructions to set up `tuono` on your local environment!
 
 ## Setup
 
@@ -67,7 +58,7 @@ You can see which version of yarn we use by checking the `packageManager` field 
 
 ### Pre-flight checks
 
-Check that everything is working properly run:
+To check that everything is working properly run:
 
 ```sh
 turbo run check-all
@@ -82,7 +73,7 @@ cargo build
    turbo run dev
    ```
 
-1. In another shell run
+2. In another shell run
 
    ```sh
    cargo build
@@ -94,7 +85,7 @@ cargo build
    cargo watch -x build -w crates/
    ```
 
-1. You can now use the binary inside `/target/debug/tuono` in another folder on your local machine
+3. You can now use the binary inside `/target/debug/tuono` in another folder on your local machine
 
    > Consider to add an alias to your shell setup file
    >

--- a/apps/documentation/src/routes/documentation/contributing/local-development.mdx
+++ b/apps/documentation/src/routes/documentation/contributing/local-development.mdx
@@ -1,0 +1,111 @@
+import MetaTags from '../../../components/meta-tags'
+
+<MetaTags
+  title="Tuono - Contributing - Local development"
+  canonical="https://tuono.dev/documentation/contributing/local-development"
+  description="The project is massive - if you like it, do consider contributing!"
+/>
+
+import Breadcrumbs, { Element } from '../../../components/breadcrumbs'
+
+<Breadcrumbs breadcrumbs={[{ label: '✨ Contributing' }]} />
+
+# Local development
+
+Thanks for your interest! In this page you find the instructions to setup the `tuono`!
+
+## Quick setup
+
+```sh
+git clone https://github.com/<your-name-here>/tuono
+cd tuono
+pnpm i
+pnpm run check-all
+```
+
+## Setup
+
+### Fork and clone repository
+
+After [forking the repo on Github](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo):
+
+```sh
+git clone https://github.com/<your-name-here>/tuono
+cd tuono
+```
+
+### Rust tool chain
+
+Install the Rust programming language tool chain (`rust` and `cargo`).
+Follows instructions in the official [docs](https://rustup.rs/)
+
+### NodeJS - runtime
+
+Install `NodeJS`.
+You can follow the instructions from the [Node official site](https://nodejs.org/en/download/package-manager)
+
+> 💡 This project has a `.nvmrc` file to specify the node version used in development.
+>
+> Consider to use [nvm](https://github.com/nvm-sh/nvm) so you can run
+>
+> ```sh
+> nvm use
+> ```
+>
+> to simply pickup the correct version!
+
+### NodeJS - package manager
+
+We use [`pnpm`](https://pnpm.io) as `NodeJS` package manager.
+
+You can see which version of yarn we use by checking the `packageManager` field in the root `package.json`.
+
+### Pre-flight checks
+
+To check that everting is working correctly run:
+
+```sh
+turbo run check-all
+cargo build
+```
+
+## Tuono development
+
+1. Start tuono frontend build using
+
+   ```sh
+   turbo run dev
+   ```
+
+1. In another shell run
+
+   ```sh
+   cargo build
+   ```
+
+1. You can now use the binary inside `/target/debug/tuono` in another folder on your local machine
+
+   > Consider to add an alias to your shell setup file
+   >
+   > ```sh
+   > alias t="/path-to-repo/target/debug/tuono"
+   > ```
+
+## Documentation development
+
+1. Change the current working directory to the docs folder:
+
+   ```sh
+   cd apps/documentation
+   ```
+
+2. Run
+
+   ```sh
+   tuono dev
+   ```
+
+3. Open the localhost URL.
+
+> On the documentation remember that `tuono` `npm` package is installed from the registry and
+> it is not linked to the repository.

--- a/apps/documentation/src/routes/documentation/contributing/local-development.mdx
+++ b/apps/documentation/src/routes/documentation/contributing/local-development.mdx
@@ -3,7 +3,7 @@ import MetaTags from '../../../components/meta-tags'
 <MetaTags
   title="Tuono - Contributing - Local development"
   canonical="https://tuono.dev/documentation/contributing/local-development"
-  description="The project is massive - if you like it, do consider contributing!"
+  description="Contribute to Tuono. Learn here how to setup the repository for local development"
 />
 
 import Breadcrumbs, { Element } from '../../../components/breadcrumbs'

--- a/apps/documentation/src/routes/documentation/contributing/local-development.mdx
+++ b/apps/documentation/src/routes/documentation/contributing/local-development.mdx
@@ -35,9 +35,9 @@ cd tuono
 Install the Rust programming language tool chain (`rust` and `cargo`).
 Follows instructions in the official [docs](https://rustup.rs/)
 
-### NodeJS — runtime
+### Node.js — runtime
 
-Install `NodeJS`.
+Install `Node.js`.
 You can follow the instructions from the [Node official site](https://nodejs.org/en/download/package-manager)
 
 > 💡 This project has a `.nvmrc` file to specify the node version used in development.
@@ -48,17 +48,17 @@ You can follow the instructions from the [Node official site](https://nodejs.org
 > nvm use
 > ```
 >
-> to simply pickup the correct version!
+> to simply pick up the correct version!
 
-### NodeJS — package manager
+### Node.js — package manager
 
-We use [`pnpm`](https://pnpm.io) as `NodeJS` package manager.
+We use [`pnpm`](https://pnpm.io) as Node.js package manager.
 
 You can see which version of yarn we use by checking the `packageManager` field in the root `package.json`.
 
 ### Pre-flight checks
 
-To check that everything is working properly run:
+To check that everything is working properly, run:
 
 ```sh
 turbo run check-all
@@ -73,7 +73,7 @@ cargo build
    turbo run dev
    ```
 
-2. In another shell run
+2. In another terminal run
 
    ```sh
    cargo build
@@ -87,7 +87,7 @@ cargo build
 
 3. You can now use the binary inside `/target/debug/tuono` in another folder on your local machine
 
-   > Consider to add an alias to your shell setup file
+   > Consider adding an alias to your shell setup file
    >
    > ```sh
    > alias t="/path-to-repo/target/debug/tuono"
@@ -95,7 +95,7 @@ cargo build
 
 ## Documentation development
 
-1. Change the current working directory to the docs folder:
+1. Change the current working directory to the documentation folder:
 
    ```sh
    cd apps/documentation


### PR DESCRIPTION
## Context & Description

Close #91.

<details>

<summary>Page preview</summary>

![Screenshot 2024-11-22 at 12 50 19](https://github.com/user-attachments/assets/3cd06ea1-ef03-44eb-86ca-c9ba744b3bcd)

</details>


### Consideration

if you find the page too long, we could consider to split it into 3 different pages:
- setup
- development
- documentation
