### PR TITLE
ci: add `windows-latest` to test matrix for both `rust` and `typescript`

### DIFF
--- a/.github/workflows/repo-root-ci.yml
+++ b/.github/workflows/repo-root-ci.yml
@@ -28,4 +28,4 @@ jobs:
         uses: ./.github/actions/install-node-dependencies
 
       - name: Test project
-        run: pnpm repo:root:format
+        run: pnpm repo:root:format:check

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,6 +14,31 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  build_and_test:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    name: Build and test rust crates
+
+    strategy:
+      fail-fast: true
+      matrix:
+        os:
+          - 'ubuntu-latest'
+          - 'windows-latest'
+        toolchain:
+          - stable
+          - beta
+          - nightly
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - run: cargo build --verbose
+      - run: cargo test --verbose
+
   lint_and_fmt:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: Check format and lint rust crates
@@ -25,21 +50,3 @@ jobs:
 
       - run: cargo fmt --all -- --check
       - run: cargo clippy -- -D warnings
-
-  build_and_test:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-    name: Build and test rust crates
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        toolchain:
-          - stable
-          - beta
-          - nightly
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
-      - run: cargo build --verbose
-      - run: cargo test --verbose

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -11,11 +11,19 @@ on:
       - 'packages/**'
 
 jobs:
-  build-and-test:
+  build_and_test:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: Check build and test
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: true
+      matrix:
+        os:
+          - 'ubuntu-latest'
+          - 'windows-latest'
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout code
@@ -30,7 +38,7 @@ jobs:
       - name: Test project
         run: pnpm test
 
-  fmt-lint-and-types:
+  lint_and_fmt:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: Check format and lint
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "docs:format": "turbo format --filter=documentation",
     "docs:format:check": "turbo format:check --filter=documentation",
     "docs:types": "turbo types --filter=documentation",
+    "repo:root:format:check": "prettier . !./apps/** !./assets/** !./benches/** !./crates !./examples !./packages/** --check",
     "repo:root:format": "prettier . !./apps/** !./assets/** !./benches/** !./crates !./examples !./packages/** --write",
     "check-all": "turbo build lint format:check types --filter=!./examples"
   },


### PR DESCRIPTION
## Context & Description

Related to #150.

### Additional changes:

- `package.json` `report:format` scripts were incorrect
- make jobs order consistent between `rust` and `typescript` workflows 

<!--
Thank you for your Pull Request.

Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/Valerioageno/tuono/blob/main/CONTRIBUTING.md
-->
