### PR TITLE
ci: trigger workflow only on `push` only on `main`

### DIFF
--- a/.github/workflows/ci-documentation.yml
+++ b/.github/workflows/ci-documentation.yml
@@ -14,10 +14,9 @@ on:
 
 jobs:
   build:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: Check build
-    timeout-minutes: 15
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code
@@ -36,9 +35,8 @@ jobs:
         working-directory: ./apps/documentation
         run: tuono build --static
 
-  fmt-lint-and-types:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-    name: Check format and lint
+  code_check:
+    name: Check format, lint and types
     runs-on: ubuntu-latest
     timeout-minutes: 15
 

--- a/.github/workflows/ci-documentation.yml
+++ b/.github/workflows/ci-documentation.yml
@@ -2,6 +2,8 @@ name: Documentation Website CI
 
 on:
   push:
+    branches:
+      - main
     paths:
       - '.github/**'
       - 'apps/documentation/**'

--- a/.github/workflows/deploy-documentation.yml
+++ b/.github/workflows/deploy-documentation.yml
@@ -1,4 +1,5 @@
 name: Deploy documentation website on AWS S3
+
 on:
   push:
     branches:
@@ -9,6 +10,7 @@ on:
 
 jobs:
   deploy-documentation:
+    name: Deploy
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,14 @@
 name: Publish on npm and crates
+
 on:
   release:
     types: [published]
 
 jobs:
-  publish-on-npm-dry-run:
+  publish_npm_dry_run:
+    name: NPM publish (dry run)
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -23,8 +26,10 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-  publish-on-crates-dry-run:
+  publish_crates_dry_run:
+    name: Crates publish (dry run)
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -41,9 +46,11 @@ jobs:
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
           check-repo: true
 
-  publish-on-npm:
-    needs: [publish-on-crates-dry-run, publish-on-npm-dry-run]
+  publish_npm:
+    name: NPM publish
+    needs: [publish_npm_dry_run, publish_crates_dry_run]
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -64,9 +71,11 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-  publish-on-crates:
-    needs: [publish-on-crates-dry-run, publish-on-npm-dry-run]
+  publish_crates:
+    name: Crates publish
+    needs: [publish_npm_dry_run, publish_crates_dry_run]
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/repo-root-ci.yml
+++ b/.github/workflows/repo-root-ci.yml
@@ -5,6 +5,8 @@ name: Repo root CI
 
 on:
   push:
+    branches:
+      - main
     paths:
       - '.github/**'
       - './*'

--- a/.github/workflows/repo-root-ci.yml
+++ b/.github/workflows/repo-root-ci.yml
@@ -17,10 +17,9 @@ on:
 
 jobs:
   build-and-test:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: Check format
-    timeout-minutes: 15
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,6 @@ env:
 
 jobs:
   build_and_test:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: Build and test rust crates
 
     strategy:
@@ -43,7 +42,6 @@ jobs:
       - run: cargo test --verbose
 
   lint_and_fmt:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: Check format and lint rust crates
     runs-on: ubuntu-latest
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,6 +2,8 @@ name: Rust CI
 
 on:
   push:
+    branches:
+      - main
     paths:
       - '.github/**'
       - 'crates/**'

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -14,7 +14,6 @@ on:
 
 jobs:
   build_and_test:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: Check build and test
     timeout-minutes: 15
 
@@ -42,7 +41,6 @@ jobs:
         run: pnpm test
 
   lint_and_fmt:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: Check format and lint
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -2,6 +2,8 @@ name: Typescript CI
 
 on:
   push:
+    branches:
+      - main
     paths:
       - '.github/**'
       - 'packages/**'


### PR DESCRIPTION
## Context & Description

`push` should trigger CI only when performed on  `main` branch

> [!NOTE] 
> CI is still executed on every push on a branch with an opened PR.
> (The PR target can be any branch)
