### PR TITLE
ci(rust): avoid `beta` and `nightly` toolchains to be executed on macos and windows

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   build_and_test:
-    name: Build and test rust crates
+    name: Build and test crates on ${{ matrix.os }} with rust ${{ matrix.toolchain }}
 
     strategy:
       fail-fast: true
@@ -27,9 +27,15 @@ jobs:
           - 'macos-latest'
           - 'windows-latest'
         toolchain:
-          - stable
-          - beta
-          - nightly
+          - 'stable'
+
+        # Test `beta` and `nightly` toolchains only on `ubuntu`
+        # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/running-variations-of-jobs-in-a-workflow#expanding-or-adding-matrix-configurations
+        include:
+          - toolchain: 'beta'
+            os: 'ubuntu-latest'
+          - toolchain: 'nightly'
+            os: 'ubuntu-latest'
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
## Context & Description

On  `rust` CI remove `nightly` and `beta` toolchains from `windows` and `macOS`

<!--
Thank you for your Pull Request.

Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/Valerioageno/tuono/blob/main/CONTRIBUTING.md
-->
