### PR TITLE
feat: add --no-js-emit flag to tuono build command

### DIFF
--- a/crates/tuono/src/source_builder.rs
+++ b/crates/tuono/src/source_builder.rs
@@ -123,7 +123,7 @@ fn create_modules_declaration(routes: &HashMap<String, Route>) -> String {
     route_declarations
 }
 
-pub fn bundle_axum_source(mode: Mode) -> io::Result<()> {
+pub fn bundle_axum_source(mode: Mode) -> io::Result<App> {
     let base_path = std::env::current_dir().unwrap();
 
     let app = App::new();
@@ -132,7 +132,7 @@ pub fn bundle_axum_source(mode: Mode) -> io::Result<()> {
 
     create_main_file(&base_path, &bundled_file);
 
-    Ok(())
+    Ok(app)
 }
 
 fn generate_axum_source(app: &App, mode: Mode) -> String {


### PR DESCRIPTION
## Context & Description

<!--
Thank you for your Pull Request.

Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/Valerioageno/tuono/blob/main/CONTRIBUTING.md
-->

In order to ease the testing suite development - that in the rust side doesn't need to build the react related modules - we add with this PR the new `--no-js-emit` flag to the `tuono build` command in order to just build the rust assets
